### PR TITLE
docs: fix minor typo in contributing docs

### DIFF
--- a/docs/community/issues-and-prs.mdx
+++ b/docs/community/issues-and-prs.mdx
@@ -1,10 +1,10 @@
 ---
 title: Issues and PR
-description: Issues and Pull Request Guiedlines
+description: Issues and Pull Request Guidelines
 sidebar_position: 2
 ---
 
-# Issues and Pull Request Guiedlines
+# Issues and Pull Request Guidelines
 
 Hi there! We're thrilled that you'd like to contribute to this project, thank you for your interest. Whether it's a bug report, new feature, correction, or additional documentation, we greatly value feedback and contributions from our community.
 


### PR DESCRIPTION
- This PR fixes a small typo in the contributing documentation to enhance clarity and readability.
- Fixes: #22 