### PR TITLE
fix: make GitHub logo responsive in navbar on smaller screens

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -33,7 +33,7 @@
 
     /* Docusaurus color */
     --prism-background-color: #edefff;
-    --ifm-color-primary: #193AE6;
+    --ifm-color-primary: #193ae6;
     --ifm-color-primary-lightest: #c8c7ff;
     --ifm-footer-background-color: #242526;
     --ifm-footer-link-color: #333;
@@ -41,9 +41,10 @@
     --ifm-h1-font-size: 2.5rem;
     --docusaurus-highlighted-code-line-bg: #0000001a;
     --ifm-global-shadow-tl: 2px 3px 5px 0 rgba(0, 0, 0, 0.2), 0 2px 4px 0 rgba(0, 0, 0, 0.1);
-    --ifm-font-family-base: Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, system-ui,
-      -apple-system, sans-serif, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
-      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    --ifm-font-family-base:
+      Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, system-ui, -apple-system, sans-serif,
+      BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+      'Segoe UI Emoji', 'Segoe UI Symbol';
     --menu-link-active: rgba(0, 0, 0, 0.1);
     --ifm-menu-link-padding-vertical: 0.5rem;
     --docs-fg-base: #030712;
@@ -51,10 +52,9 @@
 
     /* Docsearch color */
     --docsearch-key-gradient: linear-gradient(-225deg, #d5dbe4, #f8f8f8);
-    --docsearch-key-shadow: inset 0 -2px 0 0 #cdcde6, inset 0 0 1px 1px #fff,
-      0 1px 2px 1px #1e235a66;
+    --docsearch-key-shadow:
+      inset 0 -2px 0 0 #cdcde6, inset 0 0 1px 1px #fff, 0 1px 2px 1px #1e235a66;
     --docsearch-muted-color: #969faf;
-
 
     --ifm-table-background: transparent;
     --ifm-table-stripe-background: transparent;
@@ -65,7 +65,6 @@
     --color-blue-30: hsl(240, 100%, 98%);
     --color-grey-40: hsl(240, 25%, 98%);
     --doc-sidebar-width: 200px;
-
   }
 
   html[data-theme='dark'] {
@@ -113,8 +112,8 @@
     --docusaurus-highlighted-code-line-bg: #0000004d;
     --docsearch-muted-color: #7f8497;
     --docsearch-key-gradient: linear-gradient(-26.5deg, #565872, #31355b);
-    --docsearch-key-shadow: inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px #51577d,
-      0 2px 2px 0 #0304094d;
+    --docsearch-key-shadow:
+      inset 0 -2px 0 0 #282d55, inset 0 0 1px 1px #51577d, 0 2px 2px 0 #0304094d;
     --color-white: hsl(0, 0%, 16%);
     --color-grey-40: hsl(240, 14%, 14%);
     --color-blue-30: hsl(252, 25%, 18%);
@@ -211,26 +210,26 @@ a[class^='footerLogoLink_'] {
 }
 
 /* Base link or icon container */
-.header-github-link {
-  display: inline-block;
+.header-github-link::before {
+  content: '';
   width: 28px;
   height: 28px;
   margin-right: 12px;
-  /* Use the light-mode SVG by default */
-  background: url("/img/logo/github-light.svg") no-repeat center / contain;
-  transition: opacity 0.2s ease;
+  display: flex;
+  background-image: url('/img/logo/github-light.svg');
+  background-size: cover;
+  transition: background-color var(--ifm-transition-fast) var(--ifm-transition-timing-default);
 }
 
 /* Override for dark theme */
-:root[data-theme='dark'] .header-github-link {
-  background-image: url("/img/logo/github-dark.svg");
+:root[data-theme='dark'] .header-github-link::before {
+  background-image: url('/img/logo/github-dark.svg');
 }
 
 /* Optional hover effect */
 .header-github-link:hover {
   opacity: 0.8;
 }
-
 
 .header-slack-link::before {
   content: '';
@@ -242,7 +241,6 @@ a[class^='footerLogoLink_'] {
   background-size: cover;
   transition: background-color var(--ifm-transition-fast) var(--ifm-transition-timing-default);
 }
-
 
 /*  Keyboard search keys */
 kbd {
@@ -314,7 +312,7 @@ div[class^='docItemContainer_'] article img {
 
 /* nabvar button css start */
 .dev-portal-link {
-  background-color: #193AE6;
+  background-color: #193ae6;
   border-radius: 4px;
   transition-property: all;
   padding: 0.25rem 0.75rem !important;
@@ -369,8 +367,6 @@ div[class^='docItemContainer_'] article img {
   margin-top: 1.1em;
 }
 
-
-
 table {
   border-spacing: 0;
   border-collapse: separate;
@@ -385,7 +381,6 @@ table td {
 /* [data-theme='dark'] table td {
   border-color: black;
 } */
-
 
 /* Add these new styles */
 table th:first-child {


### PR DESCRIPTION
- This PR fixes a visual bug where the GitHub logo in the mobile navbar was not rendering correctly.
- Fixes: #24 
