### PR TITLE
Feat/trino playground doc

### DIFF
--- a/docs/playground/olake-iceberg-trino-playground.md
+++ b/docs/playground/olake-iceberg-trino-playground.md
@@ -1,31 +1,29 @@
-/var/folders/04/wfhtcpsx73v5zgpjjv9pjp9r0000gn/T/TemporaryItems/NSIRD_screencaptureui_FlsUGA/Screenshot\ 2025-07-11\ at\ 6.04.06 PM.png  OLake + Iceberg + Trino Playground
+# OLake + Iceberg + Trino Playground
 
-This document provides instructions for setting up a local Trino playground with the TPCH connector, demonstrating basic Trino functionality through its web UI and CLI. This setup uses Docker and Docker Compose for easy deployment
- Prerequisites
+This document provides instructions for setting up a local Trino playground with the TPCH connector, demonstrating basic Trino functionality through its web UI and CLI. This setup uses Docker and Docker Compose for easy deployment.
+
+## Prerequisites
 
 Before you begin, ensure you have the following installed on your macOS system:
 
-Docker Desktop:** Install from [https://www.docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop). Ensure Docker is running.
-Homebrew:** A package manager for macOS. If not installed, follow instructions on [https://brew.sh](https://brew.sh).
-OpenJDK 17:** Required to run the Trino CLI.
-Trino CLI:** The command-line interface for Trino.
+* **Docker Desktop**: Install from [https://www.docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop). Ensure Docker is running.
+* **Homebrew**: A package manager for macOS. If not installed, follow instructions on [https://brew.sh](https://brew.sh).
+* **OpenJDK 17**: Required to run the Trino CLI.
+* **Trino CLI**: The command-line interface for Trino.
 
- Setup Steps
+## Setup Steps
 
- 1. Install Java (OpenJDK 17) and Trino CLI
+### 1. Install Java (OpenJDK 17) and Trino CLI
 
 Let's get your Java environment ready for Trino.
 
 ```bash
- Install OpenJDK 17 via Homebrew
+# Install OpenJDK 17 via Homebrew
 brew install openjdk@17
-
- Set up Java symlink for system recognition
+```bash
+# Set up Java symlink for system recognition
 sudo ln -sfn /usr/local/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
-
- Add OpenJDK 17 to your shell's PATH for command-line access
+```bash
+# Add OpenJDK 17 to your shell's PATH for command-line access
 echo 'export PATH="/usr/local/opt/openjdk@17/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
-
- Confirm Java is installed correctly
-java -version

--- a/docs/playground/olake-iceberg-trino-playground.md
+++ b/docs/playground/olake-iceberg-trino-playground.md
@@ -1,32 +1,31 @@
-# OLake + Iceberg + Trino Playground
+/var/folders/04/wfhtcpsx73v5zgpjjv9pjp9r0000gn/T/TemporaryItems/NSIRD_screencaptureui_FlsUGA/Screenshot\ 2025-07-11\ at\ 6.04.06 PM.png  OLake + Iceberg + Trino Playground
 
-This document provides instructions for setting up a local Trino playground with the TPCH connector, demonstrating basic Trino functionality through its web UI and CLI. This setup uses Docker and Docker Compose for easy deployment.
-
-## Prerequisites
+This document provides instructions for setting up a local Trino playground with the TPCH connector, demonstrating basic Trino functionality through its web UI and CLI. This setup uses Docker and Docker Compose for easy deployment
+ Prerequisites
 
 Before you begin, ensure you have the following installed on your macOS system:
 
-* **Docker Desktop:** Install from [https://www.docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop). Ensure Docker is running.
-* **Homebrew:** A package manager for macOS. If not installed, follow instructions on [https://brew.sh](https://brew.sh).
-* **OpenJDK 17:** Required to run the Trino CLI.
-* **Trino CLI:** The command-line interface for Trino.
+Docker Desktop:** Install from [https://www.docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop). Ensure Docker is running.
+Homebrew:** A package manager for macOS. If not installed, follow instructions on [https://brew.sh](https://brew.sh).
+OpenJDK 17:** Required to run the Trino CLI.
+Trino CLI:** The command-line interface for Trino.
 
-## Setup Steps
+ Setup Steps
 
-### 1. Install Java (OpenJDK 17) and Trino CLI
+ 1. Install Java (OpenJDK 17) and Trino CLI
 
 Let's get your Java environment ready for Trino.
 
 ```bash
-# Install OpenJDK 17 via Homebrew
+ Install OpenJDK 17 via Homebrew
 brew install openjdk@17
 
-# Set up Java symlink for system recognition
+ Set up Java symlink for system recognition
 sudo ln -sfn /usr/local/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
 
-# Add OpenJDK 17 to your shell's PATH for command-line access
+ Add OpenJDK 17 to your shell's PATH for command-line access
 echo 'export PATH="/usr/local/opt/openjdk@17/bin:$PATH"' >> ~/.zshrc
 source ~/.zshrc
 
-# Confirm Java is installed correctly
+ Confirm Java is installed correctly
 java -version

--- a/docs/playground/olake-iceberg-trino-playground.md
+++ b/docs/playground/olake-iceberg-trino-playground.md
@@ -1,0 +1,32 @@
+# OLake + Iceberg + Trino Playground
+
+This document provides instructions for setting up a local Trino playground with the TPCH connector, demonstrating basic Trino functionality through its web UI and CLI. This setup uses Docker and Docker Compose for easy deployment.
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed on your macOS system:
+
+* **Docker Desktop:** Install from [https://www.docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop). Ensure Docker is running.
+* **Homebrew:** A package manager for macOS. If not installed, follow instructions on [https://brew.sh](https://brew.sh).
+* **OpenJDK 17:** Required to run the Trino CLI.
+* **Trino CLI:** The command-line interface for Trino.
+
+## Setup Steps
+
+### 1. Install Java (OpenJDK 17) and Trino CLI
+
+Let's get your Java environment ready for Trino.
+
+```bash
+# Install OpenJDK 17 via Homebrew
+brew install openjdk@17
+
+# Set up Java symlink for system recognition
+sudo ln -sfn /usr/local/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
+
+# Add OpenJDK 17 to your shell's PATH for command-line access
+echo 'export PATH="/usr/local/opt/openjdk@17/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+
+# Confirm Java is installed correctly
+java -version


### PR DESCRIPTION
This PR adds comprehensive documentation for setting up the OLake + Iceberg + Trino playground using Docker Compose.

It covers:
- Prerequisites and dependencies (Docker, Java, Trino CLI)
- Step-by-step instructions for setting up the Trino coordinator and TPCH catalog
- Guidance on accessing and demonstrating functionality via the Trino UI
- Examples of interacting with Trino using the CLI
