### PR TITLE
chore: corrected database log terms

### DIFF
--- a/docs/shared/OLakeFeaturesTLDR.mdx
+++ b/docs/shared/OLakeFeaturesTLDR.mdx
@@ -5,7 +5,7 @@
 2. **Iceberg writer** – The dedicated [Iceberg Java Writer](/docs/writers/iceberg/overview) (migrating to [Iceberg Go writer](https://github.com/datazip-inc/olake/pull/337)) produces exactly-once, rollback-ready Iceberg v2 tables.
 3. **Smart partitioning** – We support both [Iceberg partitioning rules](/docs/writers/iceberg/partitioning) and[AWS S3 partitioning](/docs/writers/parquet/partitioning) for Parquet for fast scans and efficient querying.
 4. **Parallelised chunking** – OLake splits big tables into smaller chunks, slashing total faster processing and parallel execution.
-5. **Change Data Capture** – We capture WALs for Postgres, binlogs for MongoDB and oplogs for MySQL in near real-time to keep the lake fresh without reloads.
+5. **Change Data Capture** – We capture WALs for Postgres, binlogs for MySQL and oplogs for MongoDB in near real-time to keep the lake fresh without reloads.
 6. **[Schema evolution & datatype changes](/docs/features/schema)** – Column adds, drops and type promotions are auto-detected and written per Iceberg v2 spec, so pipelines never break.
 7. **Stateful, resumable syncs** – If a [job](/docs/jobs/overview) crashes (or is paused), OLake resumes from the last committed checkpoint—no manual fixes needed.
 8. **Back-off & retries** – OLake supports backoff retry count, meaning, if a sync fails, it will retry the sync after a certain period of time.


### PR DESCRIPTION
- MongoDB uses oplogs, MySQL uses binlogs