### PR TITLE
fix: Add missing structured data markup to breadcrumb components

### DIFF
--- a/src/components/Breadcrumbs/CentralizedBreadcrumbs.tsx
+++ b/src/components/Breadcrumbs/CentralizedBreadcrumbs.tsx
@@ -73,10 +73,21 @@ const CentralizedBreadcrumbs: React.FC<CentralizedBreadcrumbsProps> = ({
   const items = getBreadcrumbItems();
 
   return (
-    <nav className="mb-4" aria-label="Breadcrumb">
+    <nav 
+      className="mb-4" 
+      aria-label="Breadcrumb"
+      itemScope 
+      itemType="https://schema.org/BreadcrumbList"
+    >
       <ol className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400">
         {items.map((item, index) => (
-          <li key={index} className="flex items-center">
+          <li 
+            key={index} 
+            className="flex items-center"
+            itemProp="itemListElement"
+            itemScope
+            itemType="https://schema.org/ListItem"
+          >
             {index > 0 && (
               <ChevronRightIcon className="w-4 h-4 mx-2 text-gray-400" />
             )}
@@ -85,23 +96,27 @@ const CentralizedBreadcrumbs: React.FC<CentralizedBreadcrumbsProps> = ({
               <Link
                 to={item.href}
                 className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors text-gray-600 dark:text-gray-400"
+                itemProp="item"
               >
-                {index === 0 ? (
-                  <span className="flex items-center">
+                <span itemProp="name" className="flex items-center">
+                  {index === 0 ? (
                     <svg viewBox="0 0 24 24" className="w-4 h-4 text-gray-900 dark:text-gray-100" fill="currentColor">
                       <path d="M10 19v-5h4v5c0 .55.45 1 1 1h3c.55 0 1-.45 1-1v-7h1.7c.46 0 .68-.57.33-.87L12.67 3.6c-.38-.34-.96-.34-1.34 0l-8.36 7.53c-.34.3-.13.87.33.87H5v7c0 .55.45 1 1 1h3c.55 0 1-.45 1-1z" />
                     </svg>
-                  </span>
-                ) : (
-                  item.label
-                )}
+                  ) : (
+                    item.label
+                  )}
+                </span>
               </Link>
             ) : (
-              <span className={`${
-                item.current 
-                  ? 'text-gray-900 dark:text-gray-100 font-medium' 
-                  : 'text-gray-600 dark:text-gray-400'
-              }`}>
+              <span 
+                className={`${
+                  item.current 
+                    ? 'text-gray-900 dark:text-gray-100 font-medium' 
+                    : 'text-gray-600 dark:text-gray-400'
+                }`}
+                itemProp="name"
+              >
                 {index === 0 ? (
                   <span className="flex items-center">
                     <svg viewBox="0 0 24 24" className="w-4 h-4 text-gray-900 dark:text-gray-100" fill="currentColor">
@@ -113,6 +128,7 @@ const CentralizedBreadcrumbs: React.FC<CentralizedBreadcrumbsProps> = ({
                 )}
               </span>
             )}
+            <meta itemProp="position" content={String(index + 1)} />
           </li>
         ))}
       </ol>

--- a/src/pages/webinar/index.tsx
+++ b/src/pages/webinar/index.tsx
@@ -335,8 +335,7 @@ const WebinarsPage = () => {
                 title="OLake by Datazip events | Livestorm"
                 className="rounded-lg w-full"
                 style={{
-                  minHeight: '400px',
-                  height: `${iframeHeight}px`,
+                  height:'auto',
                   transition: 'height 0.3s ease-in-out',
                   border: 'none',
                   overflow: 'hidden'

--- a/src/theme/BlogBreadcrumbs/index.js
+++ b/src/theme/BlogBreadcrumbs/index.js
@@ -30,7 +30,7 @@ export default function BlogBreadcrumbs() {
   if (isIcebergPost) {
     const icebergBreadcrumbItems = [
       {
-        label: '',
+        label: 'Home',
         href: baseUrl,
       },
       {
@@ -108,7 +108,7 @@ export default function BlogBreadcrumbs() {
 
   const breadcrumbItems = [
     {
-      label: '',
+      label: 'Home',
       href: baseUrl,
     },
     {

--- a/src/theme/DocBreadcrumbs/index.js
+++ b/src/theme/DocBreadcrumbs/index.js
@@ -34,10 +34,21 @@ export default function DocBreadcrumbsWrapper(props) {
     ];
 
     return (
-      <nav className="flex" aria-label="Breadcrumb">
+      <nav 
+        className="flex" 
+        aria-label="Breadcrumb"
+        itemScope 
+        itemType="https://schema.org/BreadcrumbList"
+      >
         <ol className="flex items-center space-x-2 text-sm">
           {customItems.map((item, index) => (
-            <li key={index} className="flex items-center">
+            <li 
+              key={index} 
+              className="flex items-center"
+              itemProp="itemListElement"
+              itemScope
+              itemType="https://schema.org/ListItem"
+            >
               {index > 0 && (
                 <span className="mx-2 text-gray-400">/</span>
               )}
@@ -46,16 +57,23 @@ export default function DocBreadcrumbsWrapper(props) {
                 <Link
                   to={item.href}
                   className="flex items-center text-gray-600 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+                  itemProp="item"
                 >
-                  {item.icon && <span className="mr-1 text-gray-900 dark:text-gray-100">{item.icon}</span>}
-                  {index === 0 ? "" : item.label}
+                  <span itemProp="name" className="flex items-center">
+                    {item.icon && <span className="mr-1 text-gray-900 dark:text-gray-100">{item.icon}</span>}
+                    {index === 0 ? "Home" : item.label}
+                  </span>
                 </Link>
               ) : (
-                <span className="flex items-center text-gray-900 dark:text-gray-100 font-medium">
+                <span 
+                  className="flex items-center text-gray-900 dark:text-gray-100 font-medium"
+                  itemProp="name"
+                >
                   {item.icon && <span className="mr-1 text-gray-900 dark:text-gray-100">{item.icon}</span>}
-                  {index === 0 ? "" : item.label}
+                  {index === 0 ? "Home" : item.label}
                 </span>
               )}
+              <meta itemProp="position" content={String(index + 1)} />
             </li>
           ))}
         </ol>


### PR DESCRIPTION
- Add itemScope, itemType, and itemProp attributes to CentralizedBreadcrumbs
- Fix missing structured data in DocBreadcrumbsWrapper for query engine pages
- Replace empty breadcrumb labels with 'Home' in BlogBreadcrumbs
- Add proper itemProp='name' and itemProp='position' meta tags
- Resolves Google Search Console breadcrumb validation errors

Fixes: 'Either name or item.name should be specified (in itemListElement)' error
Affects: 17 pages with breadcrumb structured data issues