### PR TITLE
fix: add missing redirect for `/docs/category/oracle`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -711,6 +711,11 @@ const config = {
           },
 
           {
+            to: '/docs/connectors/oracle/overview',
+            from: '/docs/category/oracle',
+          },
+
+          {
             to: '/docs/getting-started/quickstart',
             from: '/docs/category/getting-started',
           },


### PR DESCRIPTION
The link to the to the `Oracle Docs`, which can be found here:
https://github.com/datazip-inc/olake/blob/1001235c0bd288c3e3420c8b23aa85124df7451a/drivers/oracle/README.md?plain=1#L215
is dead.

This change is an attempt to fix it.

By the way: I am not sure how to handle the _blank lines_ around the introduced block. Feel free to push preferred version to my branch.