### PR TITLE
docs:Release notes Ingestion updated with v0.6.4

### DIFF
--- a/docs/release/v0.6.0.mdx
+++ b/docs/release/v0.6.0.mdx
@@ -1,5 +1,5 @@
-# OLake (v0.6.0)
-March 21, 2026 – March 24, 2026
+# OLake (v0.6.0 - v0.6.4)
+March 21, 2026 – April 09, 2026
 
 ## 🎯 What's New
 
@@ -9,9 +9,24 @@ March 21, 2026 – March 24, 2026
 
 2. **Postgres strict SSL verification support -** <br/> Added `verify-ca` and `verify-full` SSL support for Postgres using PEM certificate content input. Also removed support for passing `sslrootcert`, `sslcert`, and `sslkey` as file paths; these fields now expect the actual PEM content instead.
 
+3. **Skip ProduceSchema overhead during sync -** <br/> Optimized sync performance by skipping heavy schema inference (like MongoDB collection scans or Kafka message decoding) during sync. Drivers now rely on the pre-discovered schema from `streams.json` via a new `SyncContext`, and `ProduceSchema` is only executed for user-selected streams rather than all available source tables/collections.
+
 ## 🔧 Bug Fixes & Stability
 
 1. **Datatype utility unit tests -** <br/> Added unit test coverage for `utils/typeutils/datatype.go` across type detection, comparison, timestamp precision, and SQL type mapping, and fixed invalid `reflect.Value` handling to map to `types.Null`.
 
 2. **Oracle incremental cursor timezone fix -** <br/> Fixed incremental cursor handling for Oracle `TIMESTAMP` and `DATE` columns by stripping the session timezone offset before saving cursor values, so TZ-naive columns don’t shift and re-read already synced records.
 
+3. **MongoDB date out of range fix -** <br/> Fixed a fatal crash (`json: error calling MarshalJSON`) during MongoDB syncs with `normalization: false` caused by dates exceeding Go's [0, 9999] year limit. Added bounds checking to clamp years `< 1` to 1970 and years `> 9999` to 9999, ensuring dates safely map to valid JSON timestamps.
+
+4. **Clear destination support for GCP -** <br/> Fixed clear destination for GCP buckets by handling the unsupported bulk delete operation and added retry backoff.
+
+5. **Increase Java writer startup timeout -** <br/> Extended the Java writer process startup timeout from 30 seconds to 600 seconds (10 minutes).
+
+6. **MongoDB nested dates out of range fix -** <br/> Fixed fatal crashes (`json: error calling MarshalJSON`) when unnormalized MongoDB documents contained nested `DateTime` values with years outside Go’s supported [0, 9999] range by configuring the MongoDB client to decode BSON `DateTime` into safe, clamped `time.Time` values at decode-time.
+
+7. **PostgreSQL backfill chunking for multi-level partitions -** <br/> Fixed a bug where multi-level partitioned PostgreSQL tables were silently skipped during backfill. The chunk discovery query now properly finds all leaf partitions (using `pg_partition_tree` for PG 12+ and a recursive `pg_inherits` CTE for older versions) instead of only looking one level deep, and stale statistics without an `ANALYZE` run now return a clear error rather than silently skipping the table.
+
+8. **Column selection integration tests -** <br/> Added integration tests for column selection to verify that only specified columns are synced. Tests cover both inclusion and exclusion logic, as well as validating that columns removed from the source during a backfill stop being ingested while the remaining columns continue processing correctly.
+
+9. **Go Security workflow vulnerability and Go version update -** <br/> Updated the Go Security workflow to make `govulncheck` respect defined exemptions (failing only on unexempted vulnerabilities) and upgraded the Go version to `v1.25.9` (which includes recent security fixes).


### PR DESCRIPTION
Updated the release notes section for Ingestion with versions:
- 0.6.1
- 0.6.2
- 0.6.3
- 0.6.4