### PR TITLE
docs: MySQL source docs update

### DIFF
--- a/docs/shared/config/MySQLToIcebergDatatypes.mdx
+++ b/docs/shared/config/MySQLToIcebergDatatypes.mdx
@@ -10,6 +10,10 @@
 
 </div>
 
+:::info INT UNSIGNED mapping change
+From OLake version `0.4.1` and above, `INT UNSIGNED` maps to `bigint` in the destination. In versions earlier than `0.4.1`, it maps to `int`.
+:::
+
 :::info timestamptz timezone
 OLake always ingests timestamp data in UTC format, independent of the source timezone.
 :::


### PR DESCRIPTION
Updated the data types section for mysql for the change in mapping of `int unsigned` to bigint from olake v0.4.1 and above