### PR TITLE
docs: refactor compose quick start and upgrade tabs

### DIFF
--- a/docs/install/olake-ui/index.mdx
+++ b/docs/install/olake-ui/index.mdx
@@ -53,9 +53,8 @@ The fastest way to get OLake UI running is with a single command:
     ```bash
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - up -d
     ```
-    *This setup uses Postgres for both metadata and Temporal visibility, eliminating the need for Elasticsearch.*
 
-    **Maintenance**
+    **Ingestion + Maintenance**
 
     To enable the maintenance stack:
 
@@ -67,6 +66,8 @@ The fastest way to get OLake UI running is with a single command:
 
     Spark maintenance executes on a Kind (Kubernetes in Docker) cluster (`fusion-cluster`) created by the Fusion profile. `fusion-db-init` downloads `config.yaml`, `kind-config.yaml`, and `spark-rbac.yaml` from the `olake-ui` GitHub repository over HTTPS at startup. Local overrides for those files are not supported at this time.
 
+    *This setup uses Postgres for both metadata and Temporal visibility, eliminating the need for Elasticsearch.*
+  
   </TabItem>
   <TabItem value="legacy" label="Legacy (with ES)">
     ```bash
@@ -125,7 +126,7 @@ To update OLake UI to the latest version, use the following commands based on yo
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - up -d
     ```
 
-    **Maintenance**
+    **Ingestion + Maintenance**
 
     Kind node containers for `fusion-cluster` are not Compose services, so they are not removed by `docker compose down`. The one-liner below removes those containers first (Docker only, no Kind CLI), then recreates the stack from the latest Compose file.
 

--- a/docs/install/olake-ui/index.mdx
+++ b/docs/install/olake-ui/index.mdx
@@ -108,16 +108,17 @@ To update OLake UI to the latest version, use the following commands based on yo
 
 <Tabs queryString="update-ui-version" groupId="olake-ui-docker-update">
   <TabItem value="latest" label="Latest (with New Features)" default>
-    There are two options available to upgrade stack, to upgrade **Ingestion + Maintainence** Stack use **option 1**, and for **Ingestion Only** stack use **option 2**.
-
+    There are two options available to upgrade stack, to upgrade **Ingestion + Maintenance** Stack use **option 1**, and for **Ingestion Only** stack use **option 2**.
+    :::info
+    To add Maintenance features in Ingestion Only stack go with option 1 only.
+    :::
+    
     **Option 1 : Upgrade Ingestion + Maintenance Stack**
 
       Kind node containers for `fusion-cluster` are not Compose services, so they are not removed by `docker compose down`. The one-liner below removes those containers first (Docker only, no Kind CLI), then recreates the stack from the latest Compose file.
 
       ```bash
-      for id in $(docker ps -aq --filter name=fusion-cluster); do docker rm -f "$id"; done; \
-      curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose --profile fusion -f - down && \
-      curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | ENABLE_OPTIMIZATION="true" docker compose --profile fusion -f - up -d
+      docker ps -aq --filter name=fusion-cluster | xargs -r docker rm -f; curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose --profile fusion -f - down && curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | ENABLE_OPTIMIZATION="true" docker compose --profile fusion -f - up -d
       ```
 
       :::warning
@@ -146,7 +147,7 @@ To update OLake UI to the latest version, use the following commands based on yo
     **Note**: Your data and configurations will be preserved as they are stored in persistent volumes and the `olake-data` directory.
 
     :::info 
-    Currently ES Stack does not have an option to upgrade to Maintainence Stack, To use maintainence feature upgrade legacy to latest stack first.
+    Currently ES Stack does not have an option to upgrade to maintenance Stack, To use maintenance feature upgrade legacy to latest stack first.
     :::
 
     **Upgrading Legacy to Latest**
@@ -322,7 +323,7 @@ Set the `TEMPORAL_RETENTION_PERIOD` environment variable in the `temporal-worker
 services:
   temporal-worker:
     environment:
-      TEMPORAL_RETENTION_PERIO: "168h" #Keeps data visible for 7 days (by default)
+      TEMPORAL_RETENTION_PERIOD: "168h" #Keeps data visible for 7 days (by default)
 ```
 
 **Configuration Constraints:**

--- a/docs/install/olake-ui/index.mdx
+++ b/docs/install/olake-ui/index.mdx
@@ -47,35 +47,24 @@ The following requirements must be met before starting:
 The fastest way to get OLake UI running is with a single command:
 
 <Tabs queryString="quick-start" groupId="olake-ui-docker-quick-start">
-  <TabItem value="new" label="New (after 30th Jan, 2026)" default>
-    **Ingestion only**
-
-    ```bash
-    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - up -d
-    ```
-
-    **Ingestion + Maintenance**
-
-    To enable the maintenance stack:
+  <TabItem value="Ingestion + Maintenance" label="Ingestion + Maintenance" default>
+    Setup Maintenance and Ingestion stack with following command:
 
     ```bash
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | ENABLE_OPTIMIZATION="true" docker compose --profile fusion -f - up -d
     ```
+  </TabItem>
+  <TabItem value="Ingestion Only" label="Ingestion Only">
+    Setup Ingestion Only stack with following command:
+    ```bash
+    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - up -d
+    ```
+  </TabItem>
+</Tabs>
 
     The OLake UI server reads `ENABLE_OPTIMIZATION` from the environment. Set `ENABLE_OPTIMIZATION="true"` in the command above to access maintenance module; the `fusion` profile starts Fusion and related services.
 
     Spark maintenance executes on a Kind (Kubernetes in Docker) cluster (`fusion-cluster`) created by the Fusion profile. `fusion-db-init` downloads `config.yaml`, `kind-config.yaml`, and `spark-rbac.yaml` from the `olake-ui` GitHub repository over HTTPS at startup. Local overrides for those files are not supported at this time.
-
-    *This setup uses Postgres for both metadata and Temporal visibility, eliminating the need for Elasticsearch.*
-  
-  </TabItem>
-  <TabItem value="legacy" label="Legacy (with ES)">
-    ```bash
-    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - up -d
-    ```
-    *This setup uses Elasticsearch for Temporal visibility and Postgres for metadata. Use this if you have existing data in Elasticsearch.*
-  </TabItem>
-</Tabs>
 
 This command will:
 - Download the latest docker-compose.yml file
@@ -118,30 +107,37 @@ x-signup-defaults:
 To update OLake UI to the latest version, use the following commands based on your setup:
 
 <Tabs queryString="update-ui-version" groupId="olake-ui-docker-update">
-  <TabItem value="new" label="New (after 30th Jan, 2026)" default>
-    **Ingestion only**
+  <TabItem value="latest" label="Latest (with New Features)" default>
+    There are two options available to upgrade stack, to upgrade **Ingestion + Maintainence** Stack use **option 1**, and for **Ingestion Only** stack use **option 2**.
+
+    **Option 1 : Upgrade Ingestion + Maintenance Stack**
+
+      Kind node containers for `fusion-cluster` are not Compose services, so they are not removed by `docker compose down`. The one-liner below removes those containers first (Docker only, no Kind CLI), then recreates the stack from the latest Compose file.
+
+      ```bash
+      for id in $(docker ps -aq --filter name=fusion-cluster); do docker rm -f "$id"; done; \
+      curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose --profile fusion -f - down && \
+      curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | ENABLE_OPTIMIZATION="true" docker compose --profile fusion -f - up -d
+      ```
+
+      :::warning
+      If you want streaming compaction of OLake-Ingested tables, upgrade **OLake Go** (Ingestion) driver version to **v0.7.0 or higher** to avoid conflicts.
+      :::
+
+
+    **Option 2 :  Upgrade Ingestion Stack**
 
     ```bash
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - down && \
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - up -d
     ```
 
-    **Ingestion + Maintenance**
-
-    Kind node containers for `fusion-cluster` are not Compose services, so they are not removed by `docker compose down`. The one-liner below removes those containers first (Docker only, no Kind CLI), then recreates the stack from the latest Compose file.
-
-    ```bash
-    for id in $(docker ps -aq --filter name=fusion-cluster); do docker rm -f "$id"; done; \
-    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose --profile fusion -f - down && \
-    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | ENABLE_OPTIMIZATION="true" docker compose --profile fusion -f - up -d
-    ```
-
-    :::warning
-    If you want to compact OLake-Ingested tables, upgrade **OLake Go** (Ingestion) driver version to **v0.7.0 or higher** to avoid any conflicts.
-    :::
+   
     
   </TabItem>
-  <TabItem value="legacy" label="Legacy (with ES)">
+  <TabItem value="legacy" label="Legacy (with Elasticsearch)">
+   
+
     ```bash
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - down && \
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - up -d
@@ -149,7 +145,11 @@ To update OLake UI to the latest version, use the following commands based on yo
 
     **Note**: Your data and configurations will be preserved as they are stored in persistent volumes and the `olake-data` directory.
 
-    **Upgrading Legacy to New**
+    :::info 
+    Currently ES Stack does not have an option to upgrade to Maintainence Stack, To use maintainence feature upgrade legacy to latest stack first.
+    :::
+
+    **Upgrading Legacy to Latest**
 
     To move from a Legacy setup (with Elasticsearch) to the new Postgres-only visibility setup, follow these steps:
 

--- a/docs/install/olake-ui/index.mdx
+++ b/docs/install/olake-ui/index.mdx
@@ -53,6 +53,10 @@ The fastest way to get OLake UI running is with a single command:
     ```bash
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | ENABLE_OPTIMIZATION="true" docker compose --profile fusion -f - up -d
     ```
+
+    The OLake UI server reads `ENABLE_OPTIMIZATION` from the environment. Set `ENABLE_OPTIMIZATION="true"` in the command above to access maintenance module; the `fusion` profile starts Fusion and related services.
+
+    Spark maintenance executes on a Kind (Kubernetes in Docker) cluster (`fusion-cluster`) created by the Fusion profile. `fusion-db-init` downloads `config.yaml`, `kind-config.yaml`, and `spark-rbac.yaml` from the `olake-ui` GitHub repository over HTTPS at startup. Local overrides for those files are not supported at this time.
   </TabItem>
   <TabItem value="Ingestion Only" label="Ingestion Only">
     Setup Ingestion Only stack with following command:
@@ -61,10 +65,6 @@ The fastest way to get OLake UI running is with a single command:
     ```
   </TabItem>
 </Tabs>
-
-    The OLake UI server reads `ENABLE_OPTIMIZATION` from the environment. Set `ENABLE_OPTIMIZATION="true"` in the command above to access maintenance module; the `fusion` profile starts Fusion and related services.
-
-    Spark maintenance executes on a Kind (Kubernetes in Docker) cluster (`fusion-cluster`) created by the Fusion profile. `fusion-db-init` downloads `config.yaml`, `kind-config.yaml`, and `spark-rbac.yaml` from the `olake-ui` GitHub repository over HTTPS at startup. Local overrides for those files are not supported at this time.
 
 This command will:
 - Download the latest docker-compose.yml file

--- a/docs/install/olake-ui/index.mdx
+++ b/docs/install/olake-ui/index.mdx
@@ -48,19 +48,16 @@ The fastest way to get OLake UI running is with a single command:
 
 <Tabs queryString="quick-start" groupId="olake-ui-docker-quick-start">
   <TabItem value="new" label="New (after 30th Jan, 2026)" default>
+    **Ingestion only**
+
     ```bash
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - up -d
     ```
     *This setup uses Postgres for both metadata and Temporal visibility, eliminating the need for Elasticsearch.*
-  </TabItem>
-  <TabItem value="legacy" label="Legacy (with ES)">
-    ```bash
-    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - up -d
-    ```
-    *This setup uses Elasticsearch for Temporal visibility and Postgres for metadata. Use this if you have existing data in Elasticsearch.*
-  </TabItem>
-  <TabItem value="fusion" label="Maintenance">
-    <div id="upgrade-to-fusion" />
+
+    **Maintenance**
+
+    To enable the maintenance stack:
 
     ```bash
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | ENABLE_OPTIMIZATION="true" docker compose --profile fusion -f - up -d
@@ -70,32 +67,12 @@ The fastest way to get OLake UI running is with a single command:
 
     Spark maintenance executes on a Kind (Kubernetes in Docker) cluster (`fusion-cluster`) created by the Fusion profile. `fusion-db-init` downloads `config.yaml`, `kind-config.yaml`, and `spark-rbac.yaml` from the `olake-ui` GitHub repository over HTTPS at startup. Local overrides for those files are not supported at this time.
 
-    :::info Note
-    `docker compose down` only tears down services defined in the Compose file. The Kind cluster `fusion-cluster` is created by the Kind CLI against the Docker API; its control-plane and worker containers are not Compose services, so they are not removed by `down`. The user-defined bridge `olake-network` is connected to those nodes (and to Compose services), so it typically remains until the Kind containers are deleted.
-
-    After `down`, remove the Kind cluster using one of the following:
-
-    - **Kind CLI** (on the host): install the [Kind CLI](https://kind.sigs.k8s.io/docs/user/quick-start/#installation), then run:
-
-      ```bash
-      kind delete cluster --name fusion-cluster
-      ```
-
-    - **Docker only** (no Kind CLI): remove the Kind node containers:
-
-      ```bash
-      docker rm -f $(docker ps -aq --filter name=fusion-cluster)
-      ```
-
-    After either option, remove the shared bridge network (same step whether `kind delete` or `docker rm` was used):
-
+  </TabItem>
+  <TabItem value="legacy" label="Legacy (with ES)">
     ```bash
-    docker network rm olake-network
+    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - up -d
     ```
-
-    Run this only after the Kind node containers are gone. If `docker network rm` fails because the network is still in use, remove or stop the remaining container and retry.
-    :::
-
+    *This setup uses Elasticsearch for Temporal visibility and Postgres for metadata. Use this if you have existing data in Elasticsearch.*
   </TabItem>
 </Tabs>
 
@@ -141,23 +118,19 @@ To update OLake UI to the latest version, use the following commands based on yo
 
 <Tabs queryString="update-ui-version" groupId="olake-ui-docker-update">
   <TabItem value="new" label="New (after 30th Jan, 2026)" default>
+    **Ingestion only**
+
     ```bash
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - down && \
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - up -d
     ```
 
-    **Note**: Your data and configurations will be preserved as they are stored in persistent volumes and the `olake-data` directory.
-  </TabItem>
-  <TabItem value="legacy" label="Legacy (with ES)">
-    ```bash
-    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - down && \
-    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - up -d
-    ```
+    **Maintenance**
 
-    **Note**: Your data and configurations will be preserved as they are stored in persistent volumes and the `olake-data` directory.
-  </TabItem>
-  <TabItem value="fusion-update" label="Maintenance">
+    Kind node containers for `fusion-cluster` are not Compose services, so they are not removed by `docker compose down`. The one-liner below removes those containers first (Docker only, no Kind CLI), then recreates the stack from the latest Compose file.
+
     ```bash
+    for id in $(docker ps -aq --filter name=fusion-cluster); do docker rm -f "$id"; done; \
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose --profile fusion -f - down && \
     curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | ENABLE_OPTIMIZATION="true" docker compose --profile fusion -f - up -d
     ```
@@ -170,40 +143,24 @@ To update OLake UI to the latest version, use the following commands based on yo
     - Data and configurations will be preserved as they are stored in persistent volumes and the `olake-data` directory. 
     - The `--profile fusion` flag need to be applied on `down` and `up` so Fusion profile services stop and start consistently.
     
-    :::info Note
-    `docker compose down` only tears down services defined in the Compose file. The Kind cluster `fusion-cluster` is created by the Kind CLI against the Docker API; its control-plane and worker containers are not Compose services, so they are not removed by `down`. The user-defined bridge `olake-network` is connected to those nodes (and to Compose services), so it typically remains until the Kind containers are deleted.
-
-    After `down`, remove the Kind cluster using one of the following:
-
-    - **Kind CLI** (on the host): install the [Kind CLI](https://kind.sigs.k8s.io/docs/user/quick-start/#installation), then run:
-
-      ```bash
-      kind delete cluster --name fusion-cluster
-      ```
-
-    - **Docker only** (no Kind CLI): remove the Kind node containers:
-
-      ```bash
-      docker rm -f $(docker ps -aq --filter name=fusion-cluster)
-      ```
-
-    After either option, remove the shared bridge network (same step whether `kind delete` or `docker rm` was used):
-
+  </TabItem>
+  <TabItem value="legacy" label="Legacy (with ES)">
     ```bash
-    docker network rm olake-network
+    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - down && \
+    curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - up -d
     ```
 
-    Run this only after the Kind node containers are gone. If `docker network rm` fails because the network is still in use, remove or stop the remaining container and retry.
-    :::
-  </TabItem>
-  <TabItem value="upgrade" label="Upgrading Legacy to New">
-      To move from a Legacy setup (with Elasticsearch) to the new Postgres-only visibility setup, follow these steps:
+    **Note**: Your data and configurations will be preserved as they are stored in persistent volumes and the `olake-data` directory.
+
+    **Upgrading Legacy to New**
+
+    To move from a Legacy setup (with Elasticsearch) to the new Postgres-only visibility setup, follow these steps:
 
       1. Stop and remove the existing legacy stack:
         ```bash
         curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose.yml | docker compose -f - down
         ```
-      2. Start the new stack:
+    2. Start the new stack:
         ```bash
         curl -sSL https://raw.githubusercontent.com/datazip-inc/olake-ui/master/docker-compose-v1.yml | docker compose -f - up -d
         ```
@@ -212,7 +169,7 @@ To update OLake UI to the latest version, use the following commands based on yo
       When upgrading from the Legacy setup to the New setup, **existing job logs and workflow history** stored in Elasticsearch will **not** be visible in the new setup. Only new jobs and logs generated after the upgrade will be visible. 
 
       If you require access to historical logs and job history, continue using the **Legacy Setup**.
-      :::
+    :::
   </TabItem>
 </Tabs>
 

--- a/docs/install/olake-ui/index.mdx
+++ b/docs/install/olake-ui/index.mdx
@@ -139,10 +139,6 @@ To update OLake UI to the latest version, use the following commands based on yo
     :::warning
     If you want to compact OLake-Ingested tables, upgrade **OLake Go** (Ingestion) driver version to **v0.7.0 or higher** to avoid any conflicts.
     :::
-
-    **Note**: 
-    - Data and configurations will be preserved as they are stored in persistent volumes and the `olake-data` directory. 
-    - The `--profile fusion` flag need to be applied on `down` and `up` so Fusion profile services stop and start consistently.
     
   </TabItem>
   <TabItem value="legacy" label="Legacy (with ES)">


### PR DESCRIPTION
# Summary (aligned with deployment flows)
Supports the three setups discussed:

- **Full fresh deployment** — Docs now keep both paths under Quick Start → New: Ingestion only and Maintenance (ENABLE_OPTIMIZATION="true" + --profile fusion) as separate subsections instead of a third tab.

- **Upgrade from ingestion to ingestion + compaction** — Updating OLake UI Version → New is split into Ingestion only vs Maintenance so ingestion-only stacks have a matching upgrade snippet; maintenance is layered with the Fusion profile alongside the same file source.

- **Upgrade AMS / compaction params (compaction → compaction)** — Maintenance upgrade is a single scripted path: docker rm Kind node containers (fusion-cluster), then --profile fusion down/up with streamed docker-compose-v1.yml, avoiding reliance on Kind CLI and replacing the longer manual Kind/network notes.

---

# Screenshots
<img width="1060" height="743" alt="image" src="https://github.com/user-attachments/assets/8d889adb-a02b-4baf-b8de-05e54b56029d" />

<img width="1047" height="891" alt="image" src="https://github.com/user-attachments/assets/9ee726df-bf79-45f6-be59-f6661a21c379" />

<img width="1091" height="808" alt="image" src="https://github.com/user-attachments/assets/9f290088-8cc1-4c5b-945a-9dbd9b4493ee" />
