### PR TITLE
fusion-vs-spark-benchmark-title-update

### DIFF
--- a/blog/2026-04-22-spark-vs-fusion-compaction.mdx
+++ b/blog/2026-04-22-spark-vs-fusion-compaction.mdx
@@ -1,6 +1,6 @@
 ---
 slug: iceberg-compaction-spark-vs-fusion-benchmark
-title: "50% Cheaper and 2x Faster Iceberg Compaction: OLake Fusion (Open Source) Beats Spark"
+title: "50% Cheaper (2x Faster) Iceberg Compaction: OLake Fusion (Open Source) Beats Spark"
 description: "We benchmark Spark rewrite_data_files against OLake Fusion compaction on Apache Iceberg by running a full TPCH lineitem load from Postgres to GCP, applying 200k-record CDC batches every 2 minutes, and tracking TPC-H Query 6 performance, runtime, resource usage, and infrastructure cost."
 tags: [iceberg, tpch, compaction, benchmark, spark, olake, fusion]
 authors: [nayan]


### PR DESCRIPTION
updated benchmark title from 50% cheaper and 2x faster -> 50% cheaper (2x faster)