### PR TITLE
docs: Remove `normalisation=true` mandatory info from data partitioning

### DIFF
--- a/docs/writers/iceberg/partitioning.mdx
+++ b/docs/writers/iceberg/partitioning.mdx
@@ -141,10 +141,9 @@ Check all the available transforms [below](#supported-transformations).
 
 1. Before adding partitioning, make sure you have [configured your destination](/docs/getting-started/creating-first-pipeline#3-configure-destination).
 2. Then select your table.
-3. Keep **Normalization** enabled.
-4. Select **Partitioning** in the right tab.
-5. Add your **partition field** along with the **transform**.
-6. Then we can move forward to [Schedule a Job](/docs/getting-started/creating-first-pipeline#5-schedule-job).
+3. Select **Partitioning** in the right tab.
+4. Add your **partition field** along with the **transform**.
+5. Then we can move forward to [Schedule a Job](/docs/getting-started/creating-first-pipeline#5-schedule-job).
 
 <div className="center-image">
 
@@ -167,7 +166,6 @@ Check all the available transforms [below](#supported-transformations).
       {
         "stream_name": "my_stream",
         "partition_regex": "/{created_at, year}",
-        "normalization": true
       }
     ]
   }


### PR DESCRIPTION
Removed the normalisation equals true as mandatory setting before applying the data partitioning as now data partitioning can be applied with normalisation false as well