### PR TITLE
docs: Update Ingestion release notes with v0.7.2

### DIFF
--- a/docs/release/ingestion/v0.7.0.mdx
+++ b/docs/release/ingestion/v0.7.0.mdx
@@ -1,9 +1,9 @@
 ---
-title: "OLake Go (v0.7.0 - v0.7.1)"
+title: "OLake Go (v0.7.0 - v0.7.2)"
 ---
 
-# OLake Go (v0.7.0 - v0.7.1)
-April 21, 2026 – May 05, 2026
+# OLake Go (v0.7.0 - v0.7.2)
+April 21, 2026 – May 03, 2026
 
 ## 🎯 What's New
 
@@ -28,3 +28,5 @@ April 21, 2026 – May 05, 2026
 3. **Iceberg positional delete file fix for CDC upserts -** <br/> Compaction was failing when multiple changes for the same `_olake_id` arrived in a single batch, caused by a positional delete file referencing multiple data files. Fixed by creating one positional delete file per data file reference.
 
 4. **PostgreSQL primary key discovery fix via pg_catalog -** <br/> `information_schema.key_column_usage` incorrectly included foreign key columns as primary keys, causing wrong `_olake_id` hashes, missed equality deletes, and duplicate rows in Iceberg on CDC upserts. Replaced with a `pg_catalog`-based query that returns only true primary keys and works correctly for read-only roles on managed databases like RDS, Supabase, and Render.
+
+5. **MySQL CDC charset corruption fix for non-UTF8 columns -** <br/> ENUM and string columns using non-UTF8 charsets (`utf16`, `ucs2`, `latin1`) were silently corrupted during CDC due to blind `[]byte` → `string` casts. Fixed by adding collation-aware decoding using `TableMapEvent.CollationMap()` and `EnumSetCollationMap()`.


### PR DESCRIPTION
Update the release notes section for OLake Go with latest version