### PR TITLE
docs: Update postgres docs with info to retain full row

### DIFF
--- a/docs/connectors/postgres/setup/aurora.mdx
+++ b/docs/connectors/postgres/setup/aurora.mdx
@@ -200,7 +200,7 @@ INSERT INTO test_table (data) VALUES ('PostgreSQL pgoutput CDC test - INSERT');
 ```
 
 :::note Delete records and full row values
-By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row:
+By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row run the following query:
 
 ```sql
 ALTER TABLE test_table REPLICA IDENTITY FULL;

--- a/docs/connectors/postgres/setup/aurora.mdx
+++ b/docs/connectors/postgres/setup/aurora.mdx
@@ -199,6 +199,14 @@ ALTER PUBLICATION olake_publication ADD TABLE test_table;
 INSERT INTO test_table (data) VALUES ('PostgreSQL pgoutput CDC test - INSERT');
 ```
 
+:::note Delete records and full row values
+By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row:
+
+```sql
+ALTER TABLE test_table REPLICA IDENTITY FULL;
+```
+:::
+
 **Check for changes using pg_logical_slot_peek_binary_changes:**
 
 ```sql

--- a/docs/connectors/postgres/setup/azure.mdx
+++ b/docs/connectors/postgres/setup/azure.mdx
@@ -225,6 +225,14 @@ ALTER PUBLICATION olake_publication ADD TABLE test_table;
 INSERT INTO test_table (data) VALUES ('PostgreSQL pgoutput CDC test - INSERT');
 ```
 
+:::note Delete records and full row values
+By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row:
+
+```sql
+ALTER TABLE test_table REPLICA IDENTITY FULL;
+```
+:::
+
 **Check for changes using pg_logical_slot_peek_binary_changes:**
 
 ```sql

--- a/docs/connectors/postgres/setup/azure.mdx
+++ b/docs/connectors/postgres/setup/azure.mdx
@@ -226,7 +226,7 @@ INSERT INTO test_table (data) VALUES ('PostgreSQL pgoutput CDC test - INSERT');
 ```
 
 :::note Delete records and full row values
-By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row:
+By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row run the following query:
 
 ```sql
 ALTER TABLE test_table REPLICA IDENTITY FULL;

--- a/docs/connectors/postgres/setup/gcp.mdx
+++ b/docs/connectors/postgres/setup/gcp.mdx
@@ -206,7 +206,7 @@ INSERT INTO test_table (data) VALUES ('PostgreSQL pgoutput CDC test - INSERT');
 ```
 
 :::note Delete records and full row values
-By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row:
+By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row run the following query:
 
 ```sql
 ALTER TABLE test_table REPLICA IDENTITY FULL;

--- a/docs/connectors/postgres/setup/gcp.mdx
+++ b/docs/connectors/postgres/setup/gcp.mdx
@@ -205,6 +205,14 @@ ALTER PUBLICATION olake_publication ADD TABLE test_table;
 INSERT INTO test_table (data) VALUES ('PostgreSQL pgoutput CDC test - INSERT');
 ```
 
+:::note Delete records and full row values
+By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row:
+
+```sql
+ALTER TABLE test_table REPLICA IDENTITY FULL;
+```
+:::
+
 **Check for changes using pg_logical_slot_peek_binary_changes:**
 
 ```sql

--- a/docs/connectors/postgres/setup/generic.mdx
+++ b/docs/connectors/postgres/setup/generic.mdx
@@ -151,6 +151,10 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA schema1 GRANT SELECT ON TABLES TO cdc_user;
 - `INDEX`: Uses a specific unique index
 - `NOTHING`: Only INSERT operations are replicated
 
+:::note Delete records and full row values
+By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row, use **Option 2** below.
+:::
+
 **Set Replica Identity for Tables:**
 
 ```sql

--- a/docs/connectors/postgres/setup/rds.mdx
+++ b/docs/connectors/postgres/setup/rds.mdx
@@ -200,6 +200,14 @@ ALTER PUBLICATION olake_publication ADD TABLE test_table;
 INSERT INTO test_table (data) VALUES ('PostgreSQL pgoutput CDC test - INSERT');
 ```
 
+:::note Delete records and full row values
+By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row:
+
+```sql
+ALTER TABLE test_table REPLICA IDENTITY FULL;
+```
+:::
+
 **Check for changes using pg_logical_slot_peek_binary_changes:**
 
 ```sql

--- a/docs/connectors/postgres/setup/rds.mdx
+++ b/docs/connectors/postgres/setup/rds.mdx
@@ -201,7 +201,7 @@ INSERT INTO test_table (data) VALUES ('PostgreSQL pgoutput CDC test - INSERT');
 ```
 
 :::note Delete records and full row values
-By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row:
+By default, WAL only includes the primary key on deletes. In OLake, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake metadata columns — other columns appear blank or null. To retain the full deleted row run the following query:
 
 ```sql
 ALTER TABLE test_table REPLICA IDENTITY FULL;


### PR DESCRIPTION
Updated the documents for all the postgres setups to mention the proper command to access full row data.