### PR TITLE
docs: Release notes OLake Go updated with v0.7.3

### DIFF
--- a/docs/release/ingestion/v0.7.0.mdx
+++ b/docs/release/ingestion/v0.7.0.mdx
@@ -1,9 +1,9 @@
 ---
-title: "OLake Go (v0.7.0 - v0.7.2)"
+title: "OLake Go (v0.7.0 - v0.7.3)"
 ---
 
-# OLake Go (v0.7.0 - v0.7.2)
-April 21, 2026 – May 03, 2026
+# OLake Go (v0.7.0 - v0.7.3)
+April 21, 2026 – May 15, 2026
 
 ## 🎯 What's New
 
@@ -14,6 +14,8 @@ April 21, 2026 – May 03, 2026
 2. **SSH tunnel support for DB2 and MSSQL -** <br/> Added SSH tunnel configuration for the DB2 and MSSQL drivers. DB2 uses a local TCP proxy on `localhost:0` forwarded through the SSH client (`since go_ibm_db` has no Go-level dial hook), while MSSQL routes connections via `go-mssqldb's` `Connector.Dialer` and `HostDialer` interfaces with remote-side DNS resolution.
 
 3. **Schema filtering for PostgreSQL discovery -** <br/> Added an optional schemas config field to restrict the discover operation to user-specified PostgreSQL schemas. When omitted, existing behaviour is preserved and all non-system schemas are discovered.
+
+4. **MSSQL read replica support -** <br/> Added optional `jdbc_url_params` to the MSSQL source so you can target Always On read replicas (for example with read-intent), and updated CDC to use replica-safe paths that avoid primary-only agent/msdb and capture-instance management on secondaries. 
 
 ### Destinations
 
@@ -30,3 +32,7 @@ April 21, 2026 – May 03, 2026
 4. **PostgreSQL primary key discovery fix via pg_catalog -** <br/> `information_schema.key_column_usage` incorrectly included foreign key columns as primary keys, causing wrong `_olake_id` hashes, missed equality deletes, and duplicate rows in Iceberg on CDC upserts. Replaced with a `pg_catalog`-based query that returns only true primary keys and works correctly for read-only roles on managed databases like RDS, Supabase, and Render.
 
 5. **MySQL CDC charset corruption fix for non-UTF8 columns -** <br/> ENUM and string columns using non-UTF8 charsets (`utf16`, `ucs2`, `latin1`) were silently corrupted during CDC due to blind `[]byte` → `string` casts. Fixed by adding collation-aware decoding using `TableMapEvent.CollationMap()` and `EnumSetCollationMap()`.
+
+6. **MongoDB primary key pinning for deterministic deduplication -** <br/> Previously, all indexed fields were treated as primary keys, so updates to non-unique indexed fields changed the `_olake_id` and broke Iceberg equality deletes, creating duplicate rows. The primary key is now pinned strictly to MongoDB’s guaranteed-unique `_id`, ensuring stable hashes and correct deduplicated upserts.
+
+7. **DB2 driver download fix in integration tests -** <br/> DB2 integration tests now reuse the already-installed `clidriver` by copying it into the workspace, so Docker containers find it locally instead of repeatedly hitting the flaky IBM CDN download path.


### PR DESCRIPTION
Updated the release notes for OLake Go with the latest version changes