### PR TITLE
chore: add olake fusion announcement banner

### DIFF
--- a/blog/tags.yml
+++ b/blog/tags.yml
@@ -383,4 +383,52 @@ small-files:
   permalink: '/small-files'
   description: 'Blogs on the topic small files problem in data lakehouses'
 
+binpack-compaction:
+  label: 'Binpack Compaction'
+  permalink: '/binpack-compaction'
+  description: 'Blogs on Binpack Compaction'
 
+sort-compaction:
+  label: 'Sort Compaction'
+  permalink: '/sort-compaction'
+  description: 'Blogs on Sort Compaction'
+
+manifest-rewrite:
+  label: 'Manifest Rewrite'
+  permalink: '/manifest-rewrite'
+  description: 'Blogs on Manifest Rewrite'
+
+metadata-optimization:
+  label: 'Metadata Optimization'
+  permalink: '/metadata-optimization'
+  description: 'Blogs on Metadata Optimization'
+
+tpch:
+  label: 'TPC-H'
+  permalink: '/tpch'
+  description: 'Blogs on TPC-H benchmarks'
+
+benchmark:
+  label: 'Benchmark'
+  permalink: '/benchmark'
+  description: 'Blogs on benchmarking'
+
+spark:
+  label: 'Apache Spark'
+  permalink: '/spark'
+  description: 'Blogs on Apache Spark'
+
+agentic-ai:
+  label: 'Agentic AI'
+  permalink: '/agentic-ai'
+  description: 'Blogs on Agentic AI'
+
+google-cloud-lakehouse:
+  label: 'Google Cloud Lakehouse'
+  permalink: '/google-cloud-lakehouse'
+  description: 'Blogs on Google Cloud Lakehouse'
+
+mcp:
+  label: 'MCP'
+  permalink: '/mcp'
+  description: 'Blogs on Model Context Protocol (MCP)'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,13 +98,14 @@ const config = {
       // Replace with your project's social card
       image: 'img/logo/olake-blue-with-text.webp',
 
-      // announcementBar: {
-      //   id: 'monthly-events-2025',
-      //   content: 'Monthly events are <a href="/webinar" class="text-white underline hover:text-black transition-colors duration-200" aria-label="View upcoming webinars" title="View upcoming webinars">here<span class="sr-only">View upcoming webinars</span></a>. Check out! 🎉',
-      //   backgroundColor: '#193ae6',
-      //   textColor: 'white',
-      //   isCloseable: true,
-      // },
+      announcementBar: {
+        id: 'olake-fusion-launch',
+        content:
+          '<style>.fusion-banner-link:hover { color: #cbd5e1 !important; }</style><span style="letter-spacing: 0.04em;">🚀 <strong>OLake Fusion is now live!</strong> Automate your Iceberg Table Maintenance. <a href="/docs/iceberg-maintenance/overview/" class="text-white underline transition-colors duration-200 fusion-banner-link" aria-label="Check out OLake Fusion" title="Check out OLake Fusion">Check it out here<span class="sr-only">Check out OLake Fusion</span></a>. 🎉</span>',
+        backgroundColor: '#193ae6',
+        textColor: 'white',
+        isCloseable: true
+      },
 
       docs: {
         sidebar: {


### PR DESCRIPTION
## Description

This PR adds OLake Fusion announcement banner to the website and redirects to OLake Fusion Overview Page.

Also fixed build warnings of tags used in blogs not found in `tags.yml`

<img width="1795" height="85" alt="Screenshot 2026-05-25 at 3 46 03 PM" src="https://github.com/user-attachments/assets/5e80b26d-0b17-498a-bf08-a66eaff0237e" />
