### PR TITLE
docs: Update release notes for Go and Fusion

### DIFF
--- a/docs/fusion/release/maintenance/v0.1.0.mdx
+++ b/docs/fusion/release/maintenance/v0.1.0.mdx
@@ -1,9 +1,15 @@
 ---
-title: "OLake Fusion (v0.1.0 - v0.1.1)"
+title: "OLake Fusion (v0.1.0 - v0.1.2)"
 ---
 
-# OLake Fusion (v0.1.0 - v0.1.1)
-April 10, 2026 – April 15, 2026
+# OLake Fusion (v0.1.0 - v0.1.2)
+April 10, 2026 – June 11, 2026
+
+## 🎯 What's New
+
+### Catalogs
+
+1. **Test catalog connection before creation -** <br/> Added a catalog connection test API that will validate catalog credentials/configuration before creating the catalog.
 
 ## 🔧 Bug Fixes & Stability
 
@@ -12,3 +18,6 @@ April 10, 2026 – April 15, 2026
 2. **Refresh table and Fusion startup failure on catalog error -** <br/> Fixed failures in refresh table and Fusion startup caused by catalog errors, and resolved an issue with the releaser of the latest tag.
 
 3. **Glue catalog authentication fix -** <br/> Fixed authentication failures when using AWS Glue as a catalog.
+
+4. **Fail reason now visible in driver logs -** <br/> When an optimizing process fails, the failure reason is now appended to the per-process driver log files served by `LogController`.
+

--- a/docs/release/ingestion/v0.7.0.mdx
+++ b/docs/release/ingestion/v0.7.0.mdx
@@ -1,9 +1,9 @@
 ---
-title: "OLake Go (v0.7.0 - v0.7.4)"
+title: "OLake Go (v0.7.0 - v0.7.6)"
 ---
 
-# OLake Go (v0.7.0 - v0.7.4)
-April 21, 2026 – May 30, 2026
+# OLake Go (v0.7.0 - v0.7.6)
+April 21, 2026 – June 13, 2026
 
 ## 🎯 What's New
 
@@ -45,3 +45,6 @@ April 21, 2026 – May 30, 2026
 
 9. **Graceful shutdown via SIGINT/SIGTERM-aware root context -** <br/> Wired SIGINT/SIGTERM into the Cobra root context using `signal.NotifyContext`, so CDC, backfill, and destination writers now respect `ctx.Done()` and shut down cleanly on pod eviction, `docker stop`, or Ctrl-C instead of being killed mid-read.
 
+10. **Fixed edge cases in `ReformatValue` and `ReformatBool` -** <br/> Corrected two bugs in value reformatting logic, added unit test coverage for `reformat.go`.
+
+11. **Fixed TOAST column values being nulled on update events -** <br/> Unchanged TOAST columns in PostgreSQL update events were incorrectly emitted as `null` when `pgoutput` omitted the column data for unchanged values. For `REPLICA IDENTITY FULL` tables, the fix now preserves the existing value from the old tuple, preventing data loss on updates.

--- a/sidebars.js
+++ b/sidebars.js
@@ -234,12 +234,12 @@ const fusionDocSidebar = {
 
     // RELEASE NOTES
     sectionHeader("RELEASE NOTES"),
-    { type: 'doc', id: 'fusion/release/maintenance/overview', label: 'Start Here' },
+    'fusion/release/maintenance/overview',
     {
       type: 'category',
       label: 'Versions',
       items: [
-        { type: 'doc', id: 'fusion/release/maintenance/v0.1.0', label: 'v0.1.0' },
+        'fusion/release/maintenance/v0.1.0',
       ],
     },
   ],


### PR DESCRIPTION
- Updated the release notes section for OLake Go v0.7.5 and 0.7.6
- Updated the release notes section for OLake Fusion v0.1.2