### PR TITLE
docs: Update postgres troubleshooting

### DIFF
--- a/docs/connectors/postgres/index.mdx
+++ b/docs/connectors/postgres/index.mdx
@@ -261,7 +261,7 @@ By default, WAL only includes the primary key on deletes. In OLake Go, delete re
 ALTER TABLE <table_name> REPLICA IDENTITY FULL;
 ```
 
-### 5. TOAST Columns Return Null on Unrelated Updates
+### 5. TOAST Columns Return Null on updates to Non-TOAST Columns
 
 When a table has TOAST columns and an `UPDATE` modifies a non-TOAST column, PostgreSQL does not include the unchanged TOAST column value in the WAL entry. As a result, OLake Go receives no value for that column and writes `null` to the destination.
 

--- a/docs/connectors/postgres/index.mdx
+++ b/docs/connectors/postgres/index.mdx
@@ -251,6 +251,26 @@ It is more likely to happen on databases with concurrent writes or heavier CDC l
 
 **Solution**: Set `wal_sender_timeout` to `0` (recommended) or a sufficiently large value.
 
+### 4. Delete Records Only Retain the Primary Key
+
+By default, WAL only includes the primary key on deletes. In OLake Go, delete records (`_op_type = 'd'`) will therefore only retain the primary key and OLake Go metadata columns and other columns appear blank or null.
+
+**Solution**: To retain the full row values for deleted records, run the following on the affected table:
+
+```sql
+ALTER TABLE <table_name> REPLICA IDENTITY FULL;
+```
+
+### 5. TOAST Columns Return Null on Unrelated Updates
+
+When a table has TOAST columns and an `UPDATE` modifies a non-TOAST column, PostgreSQL does not include the unchanged TOAST column value in the WAL entry. As a result, OLake Go receives no value for that column and writes `null` to the destination.
+
+**Solution**: To ensure TOAST column values are always included in the WAL output, run the following on the affected table:
+
+```sql
+ALTER TABLE <table_name> REPLICA IDENTITY FULL;
+```
+
 **If the issue is not listed here, post the query on Slack to get it resolved within a few hours.**
 
 ## Changelog


### PR DESCRIPTION
Updated postgres troubleshooting with:
- Method to retain all column values for deleted records
- Method to retain the values for TOAST columns in destination when other columns get updated