### PR TITLE
docs: Update release notes OLake Go

### DIFF
--- a/docs/release/ingestion/v0.7.0.mdx
+++ b/docs/release/ingestion/v0.7.0.mdx
@@ -1,9 +1,9 @@
 ---
-title: "OLake Go (v0.7.0 - v0.7.7)"
+title: "OLake Go (v0.7.0 - v0.7.8)"
 ---
 
-# OLake Go (v0.7.0 - v0.7.7)
-April 21, 2026 – June 22, 2026
+# OLake Go (v0.7.0 - v0.7.8)
+April 21, 2026 – June 29, 2026
 
 ## 🎯 What's New
 
@@ -24,6 +24,8 @@ April 21, 2026 – June 22, 2026
 7. **Capture instance management on read replicas -** <br/> Adds an optional `primary_config` (host, port, username, password) to the MSSQL driver so CDC capture instance operations run against the Always On primary while ingestion continues from the read-only secondary. Database, SSL, and JDBC params are inherited from the main connection, and the existing `ssh_config` tunnel is reused for both connections.
 
 8. **Kafka consumer migration to Franz-Go -** <br/> Migrates the Kafka consumer from Segment `Kafka-Go` to `Franz-Go` to improve consumer group handling and to exit cleanly on rebalance behavior to avoid duplicate data writes in destination.
+
+9. **Bulk read path for DB2 backfill and incremental sync -** <br/> Adds a fast bulk-read path using a patched `go_ibm_db` driver that fetches 200 rows per ODBC call via block fetch, replacing the previous one-row-at-a-time `database/sql` scan. Column types are resolved once at setup, and a producer-consumer pipeline overlaps I/O and CPU, significantly reducing bottlenecks on large tables.
 
 ### Destinations
 
@@ -56,3 +58,8 @@ April 21, 2026 – June 22, 2026
 10. **Fixed edge cases in `ReformatValue` and `ReformatBool` -** <br/> Corrected two bugs in value reformatting logic, added unit test coverage for `reformat.go`.
 
 11. **Fixed TOAST column values being nulled on update events -** <br/> Unchanged TOAST columns in PostgreSQL update events were incorrectly emitted as `null` when `pgoutput` omitted the column data for unchanged values. For `REPLICA IDENTITY FULL` tables, the fix now preserves the existing value from the old tuple, preventing data loss on updates.
+
+12. **Fixed false LSN mismatch error during Postgres CDC 2PC recovery -** <br/> A crash after slot acknowledgement but before `state.json` was written caused a non-retryable lsn mismatch error on the next run. Fixed by skipping `validateGlobalState` when `confirmed_flush_lsn` already matches the metadata-committed LSN.
+
+13. **Bumped golang.org/x/net to v0.55.0 -** <br/> Upgraded indirect dependency across all driver modules to remediate 6 HIGH severity CVEs flagged by the `trivy-go` security scanner.
+

--- a/docs/release/ingestion/v0.7.0.mdx
+++ b/docs/release/ingestion/v0.7.0.mdx
@@ -31,7 +31,7 @@ April 21, 2026 – June 22, 2026
 
 2. **2PC integration tests -** <br/> Added integration tests for two-phase commit (2PC) to validate end-to-end behavior and improve reliability of 2PC flows.
 
-3. **Configurable destination column naming strategy -** <br/> Adds a `use_source_column_names` flag (or the **Source Naming Convention** toggle in the OLake UI) to control how destination columns are named. By default, it is disabled and column names continue to be normalized (e.g. My-Column → my_column). When enabled, original source column names are preserved as is (e.g. My-Column → My-Column).
+3. **Configurable destination column naming strategy -** <br/> Adds a `use_source_column_names` flag in CLI or the **Source Naming Convention** toggle in the UI to control how destination columns are named. By default, it is disabled and column names continue to be normalized (e.g. My-Column → my_column). When enabled, original source column names are preserved as is (e.g. My-Column → My-Column).
 
 ## 🔧 Bug Fixes & Stability
 

--- a/docs/release/ingestion/v0.7.0.mdx
+++ b/docs/release/ingestion/v0.7.0.mdx
@@ -31,7 +31,7 @@ April 21, 2026 – June 22, 2026
 
 2. **2PC integration tests -** <br/> Added integration tests for two-phase commit (2PC) to validate end-to-end behavior and improve reliability of 2PC flows.
 
-3. **Configurable destination column naming strategy -** <br/> Adds a `use_source_column_names` flag to control how destination columns are named. By default, it is disabled and column names continue to be normalized (e.g. My-Column → my_column). When enabled, original source column names are preserved as is (e.g. My-Column → My-Column).
+3. **Configurable destination column naming strategy -** <br/> Adds a `use_source_column_names` flag (or the **Source Naming Convention** toggle in the OLake UI) to control how destination columns are named. By default, it is disabled and column names continue to be normalized (e.g. My-Column → my_column). When enabled, original source column names are preserved as is (e.g. My-Column → My-Column).
 
 ## 🔧 Bug Fixes & Stability
 

--- a/docs/release/ingestion/v0.7.0.mdx
+++ b/docs/release/ingestion/v0.7.0.mdx
@@ -1,9 +1,9 @@
 ---
-title: "OLake Go (v0.7.0 - v0.7.6)"
+title: "OLake Go (v0.7.0 - v0.7.7)"
 ---
 
-# OLake Go (v0.7.0 - v0.7.6)
-April 21, 2026 – June 13, 2026
+# OLake Go (v0.7.0 - v0.7.7)
+April 21, 2026 – June 22, 2026
 
 ## 🎯 What's New
 
@@ -21,11 +21,17 @@ April 21, 2026 – June 13, 2026
 
 6. **Optimized chunking strategies for MSSQL -** <br/> Adds faster and more efficient chunk planning for MSSQL full-load syncs. Uses page-level metadata to split tables without scanning them (SQL Server 2012+, requires `VIEW DATABASE STATE`; not supported on Azure SQL DB/MI). Falls back to statistical sampling when the primary strategy is unavailable.
 
+7. **Capture instance management on read replicas -** <br/> Adds an optional `primary_config` (host, port, username, password) to the MSSQL driver so CDC capture instance operations run against the Always On primary while ingestion continues from the read-only secondary. Database, SSL, and JDBC params are inherited from the main connection, and the existing `ssh_config` tunnel is reused for both connections.
+
+8. **Kafka consumer migration to Franz-Go -** <br/> Migrates the Kafka consumer from Segment `Kafka-Go` to `Franz-Go` to improve consumer group handling and to exit cleanly on rebalance behavior to avoid duplicate data writes in destination.
+
 ### Destinations
 
 1. **Skip equality deletes for CDC inserts post-backfill -** <br/> Equality deletes are now skipped for CDC inserts once the backfill→CDC overlap window is complete, reducing unnecessary write overhead. A new `dedup_inserts` flag on the Iceberg `olake_2pc` table property tracks this — Java sets it to `true` on backfill commit, and Go clears it to `false` after the first successful CDC commit. This applies to both the Arrow and legacy gRPC writers.
 
 2. **2PC integration tests -** <br/> Added integration tests for two-phase commit (2PC) to validate end-to-end behavior and improve reliability of 2PC flows.
+
+3. **Configurable destination column naming strategy -** <br/> Adds a `use_source_column_names` flag to control how destination columns are named. By default, it is disabled and column names continue to be normalized (e.g. My-Column → my_column). When enabled, original source column names are preserved as is (e.g. My-Column → My-Column).
 
 ## 🔧 Bug Fixes & Stability
 


### PR DESCRIPTION
Updated the release notes for OLake Go with v0.7.7 and v0.7.8