### PR TITLE
docs: Update release notes Go

### DIFF
--- a/docs/release/ingestion/v0.8.0.mdx
+++ b/docs/release/ingestion/v0.8.0.mdx
@@ -1,0 +1,21 @@
+---
+title: "OLake Go (v0.8.0)"
+---
+
+# OLake Go (v0.8.0)
+June 29, 2026 – July 04, 2026
+
+## 🎯 What's New
+
+### Destinations
+
+1. **Single JVM per process for Iceberg writes -** <br/> Previously, every Iceberg writer spawned its own JVM per stream/chunk, causing excessive memory usage and OOM risk on large concurrent syncs. Now a single shared JVM handles all streams, with `ThreadSession` based isolation preserving per-stream state and cutting memory overhead.
+
+## 🔧 Bug Fixes & Stability
+
+1. **Refactored MySQL chunking helpers for testability -** <br/> Split the MySQL `GetOrSplitChunks` flow into smaller helper functions for chunk sizing, column selection, bound selection, and split strategy routing, enabling independent unit tests without changing existing chunking behavior.
+
+2. **Placeholder for unavailable TOAST values in Postgres CDC -** <br/> Added an `olake_unavailable_value` placeholder to mark unchanged TOAST columns whose values aren't available in PostgreSQL logical replication events.
+
+3. **Fixed discover failure for schema/table names containing "." -** <br/> Tables with a `.` in their schema or name (e.g. `user1.test_table`) broke discover, since namespace and name were joined into one string and later re-split on `.`, aborting discovery entirely. Fixed by carrying a `types.StreamID{Namespace, Name}` struct through the driver contract across all 8 drivers, avoiding the round-trip.
+

--- a/docs/release/ingestion/v0.8.0.mdx
+++ b/docs/release/ingestion/v0.8.0.mdx
@@ -1,9 +1,9 @@
 ---
-title: "OLake Go (v0.8.0)"
+title: "OLake Go (v0.8.0 - v0.8.1)"
 ---
 
-# OLake Go (v0.8.0)
-June 29, 2026 – July 04, 2026
+# OLake Go (v0.8.0 - v0.8.1)
+June 29, 2026 – July 09, 2026
 
 ## 🎯 What's New
 
@@ -19,3 +19,4 @@ June 29, 2026 – July 04, 2026
 
 3. **Fixed discover failure for schema/table names containing "." -** <br/> Tables with a `.` in their schema or name (e.g. `user1.test_table`) broke discover, since namespace and name were joined into one string and later re-split on `.`, aborting discovery entirely. Fixed by carrying a `types.StreamID{Namespace, Name}` struct through the driver contract across all 8 drivers, avoiding the round-trip.
 
+4. **Fixed nil pointer panic in `DropStreams` -** <br/> `destination.DropStreams` panicked when a writer returned no shutdown callback, breaking clear-destination and any path relying on `DropStreams`. Fixed by guarding against a nil shutdown callback before invoking it.

--- a/sidebars.js
+++ b/sidebars.js
@@ -158,6 +158,7 @@ const docSidebar = {
       type: 'category',
       label: 'Versions',
       items: [
+        'release/ingestion/v0.8.0',
         'release/ingestion/v0.7.0',
         'release/ingestion/v0.6.0',
         'release/ingestion/v0.5.0',


### PR DESCRIPTION
Release notes for OLake Go update with v0.8.0