### PR TITLE
Fix illegible company name text on customer story cards

### DIFF
--- a/src/components/customers/CustomerCard.tsx
+++ b/src/components/customers/CustomerCard.tsx
@@ -54,7 +54,7 @@ const CustomerCard: React.FC<CustomerCardProps> = ({
           />
           {/* Company Logo/Name Overlay */}
           <div className="absolute bottom-4 left-4 z-10">
-            <span className="text-white font-bold text-xl drop-shadow-lg">
+            <span className="text-[#193AE6] font-bold text-xl drop-shadow-lg">
               {companyName}
             </span>
           </div>


### PR DESCRIPTION

- The company name overlay on customer story cards (`CustomerCard.tsx`) used `text-white`, which blended into the background on light/illustrated card images (e.g. the Xeno card).
- Changed the text color to the brand blue `#193AE6` for consistent legibility across all cards regardless of the underlying image.