### PR TITLE
docs: Update release notes go

### DIFF
--- a/docs/release/ingestion/v0.8.0.mdx
+++ b/docs/release/ingestion/v0.8.0.mdx
@@ -1,11 +1,15 @@
 ---
-title: "OLake Go (v0.8.0 - v0.8.1)"
+title: "OLake Go (v0.8.0 - v0.8.2)"
 ---
 
-# OLake Go (v0.8.0 - v0.8.1)
-June 29, 2026 – July 09, 2026
+# OLake Go (v0.8.0 - v0.8.2)
+June 29, 2026 – July 11, 2026
 
 ## 🎯 What's New
+
+### Sources
+
+1. **2PC support for Kafka -** <br/> Adds two-phase commit support for Kafka by persisting consumer group ID, partition, and offset information in destination metadata, enabling reliable recovery so Kafka consumption can resume correctly from the last committed state.
 
 ### Destinations
 
@@ -20,3 +24,7 @@ June 29, 2026 – July 09, 2026
 3. **Fixed discover failure for schema/table names containing "." -** <br/> Tables with a `.` in their schema or name (e.g. `user1.test_table`) broke discover, since namespace and name were joined into one string and later re-split on `.`, aborting discovery entirely. Fixed by carrying a `types.StreamID{Namespace, Name}` struct through the driver contract across all 8 drivers, avoiding the round-trip.
 
 4. **Fixed nil pointer panic in `DropStreams` -** <br/> `destination.DropStreams` panicked when a writer returned no shutdown callback, breaking clear-destination and any path relying on `DropStreams`. Fixed by guarding against a nil shutdown callback before invoking it.
+
+5. **Fixed CDC insert failure on GCS via S3-compat -** <br/> CDC syncs to Iceberg on GCS failed at commit because deleting an unwritten equality-delete file returned 404 on GCS, crashing the sync. Fixed by wrapping the S3 client so a delete on a missing key is treated as success, restoring AWS-like delete behavior only when a custom `s3_endpoint` is configured.
+
+6. **Fixed partition spec column casing mismatch in Iceberg -** <br/> Table creation failed when `use_source_column_names` was disabled, since destination schema columns were normalized to lowercase (e.g. `ID` → `id`) but the partition spec payload still carried the original source column name, causing the Java writer to fail building the `PartitionSpec` against the lowercased schema. Fixed by using the resolved destination column name when populating the partition spec.


### PR DESCRIPTION
Updated he release notes section for OLake Go with v0.8.2