### PR TITLE
Add Google Analytics tag and fix broken headTags/metadata config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,5 +1,7 @@
 const imageFetchPriorityRehypePlugin = require('./src/plugins/image-fetchpriority-rehype-plugin')
 
+const GA_MEASUREMENT_ID = 'G-GTNTGHDNZW'
+
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -89,6 +91,276 @@ const config = {
       src: '/message-listener.js', // path relative to the static directory
       defer: true, // if the script must be executed in order, set async to false
       fetchpriority: 'low'
+    }
+  ],
+
+  headTags: [
+    // metadata (previously an invalid top-level `metadata` field, folded into headTags as meta tags)
+    // { tagName: 'meta', attributes: { name: 'robots', content: 'noindex, nofollow' } },
+    {
+      tagName: 'meta',
+      attributes: { name: 'OLake', content: 'ETL tool, ELT tool, open source' }
+    },
+    {
+      tagName: 'meta',
+      attributes: { name: 'twitter:card', content: 'summary_large_image' }
+    },
+    {
+      tagName: 'meta',
+      attributes: { name: 'twitter:site', content: '@olake.io' }
+    },
+    {
+      tagName: 'meta',
+      attributes: { name: 'msvalidate.01', content: 'C36AD97FE1CEDCD4041338A807D6BC4C' }
+    },
+    // Google tag (gtag.js)
+    {
+      tagName: 'script',
+      attributes: {
+        async: 'true',
+        src: `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`
+      }
+    },
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${GA_MEASUREMENT_ID}');
+      `
+    },
+    // Critical resource preloads for mobile performance
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preload',
+        href: '/img/logo/olake-blue-with-text.svg',
+        as: 'image',
+        type: 'image/svg+xml',
+        fetchpriority: 'high'
+      }
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preload',
+        href: '/img/site/hero-section.svg',
+        as: 'image',
+        type: 'image/svg+xml',
+        fetchpriority: 'high'
+      }
+    },
+    // Font optimization - preconnect to Google Fonts
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preconnect',
+        href: 'https://fonts.googleapis.com'
+      }
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preconnect',
+        href: 'https://fonts.gstatic.com',
+        crossorigin: 'anonymous'
+      }
+    },
+    // Minimal font optimization - only DNS prefetch for performance
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'dns-prefetch',
+        href: 'https://fonts.googleapis.com'
+      }
+    },
+    // DNS prefetch for external resources
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'dns-prefetch',
+        href: 'https://js.hsforms.net'
+      }
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'dns-prefetch',
+        href: 'https://www.google-analytics.com'
+      }
+    },
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'dns-prefetch',
+        href: 'https://www.googletagmanager.com'
+      }
+    },
+    // Preconnect to critical domains
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preconnect',
+        href: 'https://olake.io',
+        crossorigin: 'anonymous'
+      }
+    },
+    // Canonical URL - Removed hardcoded canonical tag
+    // Docusaurus automatically generates proper canonical URLs for each page
+    // OpenSearch meta tags
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'search',
+        type: 'application/opensearchdescription+xml',
+        title: 'OLake Documentation',
+        href: '/opensearch.xml'
+      }
+    },
+    // Enhanced Open Graph Meta Tags
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:type',
+        content: 'website'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:title',
+        content: 'OLake - The Open Lakehouse Platform'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:description',
+        content:
+          'Fastest way to replicate MongoDB data in Apache Iceberg. Open-source data lakehouse platform for modern data engineering.'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:image',
+        content: 'https://olake.io/img/logo/olake-blue.webp'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:site_name',
+        content: 'OLake'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:locale',
+        content: 'en_US'
+      }
+    },
+    // Enhanced Open Graph Meta Tags
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:image:type',
+        content: 'image/webp'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:image:width',
+        content: '1200'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        property: 'og:image:height',
+        content: '630'
+      }
+    },
+    // Enhanced Twitter Meta Tags
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:creator',
+        content: '@_olake'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:title',
+        content: 'OLake - The Open Lakehouse Platform'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:description',
+        content:
+          'OLake is the fastest data replication platform, built to stream operational databases into Apache Iceberg in real time with full CDC, incremental sync, and zero-lag reliability.'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:image',
+        content: 'https://olake.io/img/logo/olake-blue.webp'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:image:alt',
+        content: 'OLake - The Open Lakehouse Platform'
+      }
+    },
+    // Enhanced Twitter Meta Tags
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:label1',
+        content: 'Written by'
+      }
+    },
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'twitter:data1',
+        content: 'OLake Team'
+      }
+    },
+    // Enhanced Bot Directives
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'robots',
+        content: 'follow, index, max-snippet:-1, max-video-preview:-1, max-image-preview:large'
+      }
+    },
+    // Bing Webmaster Verification
+    {
+      tagName: 'meta',
+      attributes: {
+        name: 'msvalidate.01',
+        content: 'C36AD97FE1CEDCD4041338A807D6BC4C'
+      }
+    },
+    // Enhanced Favicon Support
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'icon',
+        type: 'image/svg+xml',
+        href: '/img/logo/olake-blue.svg'
+      }
     }
   ],
 
@@ -216,246 +488,6 @@ const config = {
         ]
       },
 
-      metadata: [
-        // { name: 'robots', content: 'noindex, nofollow' },
-        { name: 'OLake', content: 'ETL tool, ELT tool, open source' },
-        { name: 'twitter:card', content: 'summary_large_image' },
-        { name: 'twitter:site', content: '@olake.io' },
-        { name: 'msvalidate.01', content: 'C36AD97FE1CEDCD4041338A807D6BC4C' }
-      ],
-      headTags: [
-        // Critical resource preloads for mobile performance
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'preload',
-            href: '/img/logo/olake-blue-with-text.svg',
-            as: 'image',
-            type: 'image/svg+xml',
-            fetchpriority: 'high'
-          }
-        },
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'preload',
-            href: '/img/site/hero-section.svg',
-            as: 'image',
-            type: 'image/svg+xml',
-            fetchpriority: 'high'
-          }
-        },
-        // Font optimization - preconnect to Google Fonts
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'preconnect',
-            href: 'https://fonts.googleapis.com'
-          }
-        },
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'preconnect',
-            href: 'https://fonts.gstatic.com',
-            crossorigin: 'anonymous'
-          }
-        },
-        // Minimal font optimization - only DNS prefetch for performance
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'dns-prefetch',
-            href: 'https://fonts.googleapis.com'
-          }
-        },
-        // DNS prefetch for external resources
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'dns-prefetch',
-            href: 'https://js.hsforms.net'
-          }
-        },
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'dns-prefetch',
-            href: 'https://www.google-analytics.com'
-          }
-        },
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'dns-prefetch',
-            href: 'https://www.googletagmanager.com'
-          }
-        },
-        // Preconnect to critical domains
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'preconnect',
-            href: 'https://olake.io',
-            crossorigin: 'anonymous'
-          }
-        },
-        // Canonical URL - Removed hardcoded canonical tag
-        // Docusaurus automatically generates proper canonical URLs for each page
-        // OpenSearch meta tags
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'search',
-            type: 'application/opensearchdescription+xml',
-            title: 'OLake Documentation',
-            href: '/opensearch.xml'
-          }
-        },
-        // Enhanced Open Graph Meta Tags
-        {
-          tagName: 'meta',
-          attributes: {
-            property: 'og:type',
-            content: 'website'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            property: 'og:title',
-            content: 'OLake - The Open Lakehouse Platform'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            property: 'og:description',
-            content:
-              'Fastest way to replicate MongoDB data in Apache Iceberg. Open-source data lakehouse platform for modern data engineering.'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            property: 'og:image',
-            content: 'https://olake.io/img/logo/olake-blue.webp'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            property: 'og:site_name',
-            content: 'OLake'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            property: 'og:locale',
-            content: 'en_US'
-          }
-        },
-        // Enhanced Open Graph Meta Tags
-        {
-          tagName: 'meta',
-          attributes: {
-            property: 'og:image:type',
-            content: 'image/webp'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            property: 'og:image:width',
-            content: '1200'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            property: 'og:image:height',
-            content: '630'
-          }
-        },
-        // Enhanced Twitter Meta Tags
-        {
-          tagName: 'meta',
-          attributes: {
-            name: 'twitter:creator',
-            content: '@_olake'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            name: 'twitter:title',
-            content: 'OLake - The Open Lakehouse Platform'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            name: 'twitter:description',
-            content:
-              'OLake is the fastest data replication platform, built to stream operational databases into Apache Iceberg in real time with full CDC, incremental sync, and zero-lag reliability.'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            name: 'twitter:image',
-            content: 'https://olake.io/img/logo/olake-blue.webp'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            name: 'twitter:image:alt',
-            content: 'OLake - The Open Lakehouse Platform'
-          }
-        },
-        // Enhanced Twitter Meta Tags
-        {
-          tagName: 'meta',
-          attributes: {
-            name: 'twitter:label1',
-            content: 'Written by'
-          }
-        },
-        {
-          tagName: 'meta',
-          attributes: {
-            name: 'twitter:data1',
-            content: 'OLake Team'
-          }
-        },
-        // Enhanced Bot Directives
-        {
-          tagName: 'meta',
-          attributes: {
-            name: 'robots',
-            content: 'follow, index, max-snippet:-1, max-video-preview:-1, max-image-preview:large'
-          }
-        },
-        // Bing Webmaster Verification
-        {
-          tagName: 'meta',
-          attributes: {
-            name: 'msvalidate.01',
-            content: 'C36AD97FE1CEDCD4041338A807D6BC4C'
-          }
-        },
-        // Enhanced Favicon Support
-        {
-          tagName: 'link',
-          attributes: {
-            rel: 'icon',
-            type: 'image/svg+xml',
-            href: '/img/logo/olake-blue.svg'
-          }
-        }
-      ],
 
       colorMode: {
         defaultMode: 'light', // dark or light


### PR DESCRIPTION
## Summary
- Adds the GA4 `gtag.js` snippet (`G-GTNTGHDNZW`) site-wide, injected into every page's `<head>` via Docusaurus's `headTags` config.
- **Found and fixed a pre-existing bug**: `metadata` and `headTags` were nested inside `themeConfig`, a location Docusaurus does not read (unknown `themeConfig` keys are silently ignored). This meant they were dead code — none of the site's Open Graph tags, Twitter card tags, canonical/opensearch links, or resource preloads/preconnects were actually rendering on any page. Moved the whole block to the correct top-level config field. All that existing metadata is now restored, and GA now actually works too.

## Notes for reviewer
- `src/clientModules/analytics.ts` contains a separate, currently-unregistered analytics implementation using a different ID (`GTM-TFZ2GXJP`, a GTM container, deferred until first interaction for Core Web Vitals). It is not wired into `clientModules` and was left untouched. Worth deciding which of the two approaches (this plain gtag.js tag, vs. that deferred GTM loader) should be the long-term one, to avoid ending up with both active at once.
- Docusaurus is a client-side-routed SPA after first load. Plain `gtag('config', ...)` fires a pageview on initial load only; subsequent in-app navigations are picked up automatically only if the GA4 property's Enhanced Measurement "page changes based on browser history events" is enabled. Worth confirming that setting in the GA4 admin panel, or I can add an explicit route-change pageview hook if preferred.

## Test plan
- [x] `npm run build` succeeds with identical warning/error counts (58 HTML-minifier diagnostics, 572 broken-anchor warnings, 23 broken-link warnings) before and after this change — all pre-existing, none introduced by this PR.
- [x] Verified via build output that the GA script renders on `/`, `/docs/`, `/blog/`, and `/customer-stories/`.
- [x] Confirmed all referenced static assets (preload/favicon/opensearch targets) exist on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)