### PR TITLE
docs: Expose Prometheus metrics endpoint

### DIFF
--- a/docs/getting-started/metrics.mdx
+++ b/docs/getting-started/metrics.mdx
@@ -11,7 +11,7 @@ OLake Go UI exposes a Prometheus compatible `/metrics` endpoint so you can monit
 This is a **pull based** endpoint, point your existing Prometheus scrape config at it and metrics are available immediately. No agents, sidecars, or additional configuration are required on OLake Go's side.
 
 :::note Version Requirements
-To use the `/metrics` endpoint, upgrade **OLake UI** to version **0.X.X** or higher.
+To use the `/metrics` endpoint, **OLake UI** version should be **0.5.0** or higher.
 :::
 
 :::info

--- a/docs/getting-started/metrics.mdx
+++ b/docs/getting-started/metrics.mdx
@@ -1,0 +1,84 @@
+---
+title: Metrics
+description: Expose OLake sync and system metrics on a Prometheus-compatible `/metrics` endpoint for monitoring in Grafana and other tools.
+sidebar_position: 4
+---
+
+# Metrics
+
+OLake Go UI exposes a Prometheus compatible `/metrics` endpoint so you can monitor the health and performance of your sync jobs using standard tooling like Grafana, without parsing logs manually.
+
+This is a **pull based** endpoint, point your existing Prometheus scrape config at it and metrics are available immediately. No agents, sidecars, or additional configuration are required on OLake Go's side.
+
+:::info
+Metrics are scoped at the **job level**, reflecting each job's most recent sync run. Table level metric breakdowns are not available in this release.
+:::
+
+## Enabling the Endpoint
+
+The `/metrics` endpoint is served by the OLake Go UI backend on the same port as the UI itself at:
+
+```
+GET http://<your-olake-host>:8000/metrics
+```
+
+It's controlled by an environment variable on the OLake Go UI service:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `METRICS_ENABLED` | `true` | Set to `false` to disable the endpoint. When disabled, `/metrics` returns a `404`. |
+
+The endpoint is **unauthenticated** and sits outside the `/api` route group, so your Prometheus scraper doesn't need OLake Go UI credentials to reach it.
+
+## Metrics Specification
+
+### 1. Sync metrics
+
+These metrics show what's happening with your latest sync for each job. Think of them as a dashboard that updates with fresh numbers every time a new sync starts or completes. When a new sync begins, it replaces the previous sync's numbers.
+
+:::note
+Clear-destination runs are not included in these metrics. Only regular sync operations are tracked.
+:::
+
+| Metric | Description |
+| --- | --- |
+| `olake_sync_status` | Status of the latest sync run: <br/> `0` = running <br/> `1` = succeeded <br/> `2` = failed (a cancelled sync is also reported as failed). |
+| `olake_sync_start_time_seconds` | Unix timestamp of when the latest sync run started. |
+| `olake_sync_duration_seconds` | Duration of the run in seconds. Updates live while the sync is running, and freezes once it completes. |
+| `olake_sync_records_ingested` | Total records ingested during the run. |
+| `olake_sync_bytes_read` | Total bytes read from the source during the run. |
+
+Every sync metric carries the following labels:
+
+| Label | Description |
+| --- | --- |
+| `job_id` | Unique identifier of the job. |
+| `job_name` | Job name configured by the user. |
+| `source_name` | Source name configured by the user. |
+| `destination_name` | Destination name configured by the user. |
+
+### 2. System metrics
+
+| Metric | Description |
+| --- | --- |
+| `olake_process_cpu_usage_ratio` | CPU utilization of the sync process, as a ratio between `0` and `1`. |
+| `olake_process_memory_usage_bytes` | Memory consumed by the sync process, in bytes. |
+
+## How the data is collected
+
+Each scrape derives its response from three sources, refreshed independently:
+
+1. **Job metadata**: job, source, and destination names configured in OLake Go's Postgres database.
+2. **Run status, start time, and duration**: read from Temporal's workflow visibility, refreshed at most every 10 seconds.
+3. **Records, bytes, CPU, and memory**: read from the sync process's `stats.json` on the shared volume, refreshed at most every 2 seconds.
+
+:::info
+If updating metrics fails during a scrape, the endpoint still returns the previous values instead of returning an error.
+:::
+
+## Limitations
+
+- Metrics show only the **latest** sync run for each job. When a new sync starts, it replaces the numbers from the previous run.
+- Metrics are available at the **job level** only. You won't see per-table breakdowns in this release.
+- This endpoint exposes **metrics only**. Logs and traces are not included.
+- You need to run your own Prometheus and Grafana setup. OLake Go does not ship or manage these for you.

--- a/docs/getting-started/metrics.mdx
+++ b/docs/getting-started/metrics.mdx
@@ -64,7 +64,7 @@ Every sync metric carries the following labels:
 | `olake_process_cpu_usage_ratio` | CPU utilization of the sync process, as a ratio between `0` and `1`. |
 | `olake_process_memory_usage_bytes` | Memory consumed by the sync process, in bytes. |
 
-## How the data is collected
+## Data Collection
 
 Each scrape derives its response from three sources, refreshed independently:
 

--- a/docs/getting-started/metrics.mdx
+++ b/docs/getting-started/metrics.mdx
@@ -29,8 +29,8 @@ It's controlled by an environment variable on the OLake Go UI service:
 | `METRICS_ENABLED` | `false` | Set to `true` to enable the endpoint. When disabled, `/metrics` returns a `404`. |
 
 :::info
-- **Docker Compose:** <br/> To enable the `/metrics` endpoint, add `METRICS_ENABLED=true` under `x-envs` in your Docker Compose file. See [Service Environment Variables](/docs/install/olake-ui/#service-environment-variables) for setup details.
-- **Helm:** <br/> To enable the `/metrics` endpoint, add `METRICS_ENABLED: true` under `olakeUI` in your `values.yaml` file.
+- **Docker Compose:** <br/> To enable the `/metrics` endpoint, add `METRICS_ENABLED=true` under `x-envs` in your Docker Compose file. See [Prometheus Metrics Configuration](/docs/install/olake-ui/#prometheus-metrics-configuration) for setup details.
+- **Helm:** <br/> To enable the `/metrics` endpoint, add `METRICS_ENABLED: true` under `olakeUI` in your `values.yaml` file. See [Prometheus Metrics Configuration](/docs/install/kubernetes/#prometheus-metrics-configuration) for setup details.
 - Once enabled, metrics will be available from the next sync run. Historical metrics from previous runs are not available.
 :::
 

--- a/docs/getting-started/metrics.mdx
+++ b/docs/getting-started/metrics.mdx
@@ -26,7 +26,11 @@ It's controlled by an environment variable on the OLake Go UI service:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `METRICS_ENABLED` | `true` | Set to `false` to disable the endpoint. When disabled, `/metrics` returns a `404`. |
+| `METRICS_ENABLED` | `false` | Set to `true` to enable the endpoint. When disabled, `/metrics` returns a `404`. |
+
+:::info
+To enable the `/metrics` endpoint, add `METRICS_ENABLED=true` under `x-envs` in your Docker Compose file. See [Service Environment Variables](/docs/install/olake-ui/#service-environment-variables) for setup details.
+:::
 
 The endpoint is **unauthenticated** and sits outside the `/api` route group, so your Prometheus scraper doesn't need OLake Go UI credentials to reach it.
 
@@ -37,12 +41,13 @@ The endpoint is **unauthenticated** and sits outside the `/api` route group, so 
 These metrics show what's happening with your latest sync for each job. Think of them as a dashboard that updates with fresh numbers every time a new sync starts or completes. When a new sync begins, it replaces the previous sync's numbers.
 
 :::note
-Clear-destination runs are not included in these metrics. Only regular sync operations are tracked.
+- Clear-destination runs are not included in these metrics. Only regular sync operations are tracked.
+- The endpoint exposes only the `olake_*` series listed below (plus the scrape-error counter). The default `go_*` and `process_*` runtime metrics are intentionally not included.
 :::
 
 | Metric | Description |
 | --- | --- |
-| `olake_sync_status` | Status of the latest sync run: <br/> `0` = running <br/> `1` = succeeded <br/> `2` = failed (a cancelled sync is also reported as failed). |
+| `olake_sync_status` | Status of the latest sync run: <br/> `0` = running (a paused run also reports `0`) <br/> `1` = succeeded <br/> `2` = failed (a cancelled sync is also reported as failed). |
 | `olake_sync_start_time_seconds` | Unix timestamp of when the latest sync run started. |
 | `olake_sync_duration_seconds` | Duration of the run in seconds. Updates live while the sync is running, and freezes once it completes. |
 | `olake_sync_records_ingested` | Total records ingested during the run. |
@@ -61,8 +66,16 @@ Every sync metric carries the following labels:
 
 | Metric | Description |
 | --- | --- |
-| `olake_process_cpu_usage_ratio` | CPU utilization of the sync process, as a ratio between `0` and `1`. |
-| `olake_process_memory_usage_bytes` | Memory consumed by the sync process, in bytes. |
+| `olake_process_cpu_usage_ratio` | CPU utilization during the sync, as a ratio between `0` and `1`. |
+| `olake_process_memory_usage_bytes` | System memory in use during the sync, in bytes. |
+
+:::note Available from v0.9.0
+The following metrics require **OLake Go v0.9.0** or later:
+
+- `olake_sync_bytes_read`
+- `olake_process_cpu_usage_ratio`
+- `olake_process_memory_usage_bytes`
+:::
 
 ## Data Collection
 
@@ -73,7 +86,7 @@ Each scrape derives its response from three sources, refreshed independently:
 3. **Records, bytes, CPU, and memory**: read from the sync process's `stats.json` on the shared volume, refreshed at most every 2 seconds.
 
 :::info
-If updating metrics fails during a scrape, the endpoint still returns the previous values instead of returning an error.
+If a refresh fails during a scrape, the endpoint serves the previous values instead of erroring, and increments a `olake_metrics_scrape_errors_total` counter so scrape failures are still trackable.
 :::
 
 ## Limitations
@@ -82,3 +95,4 @@ If updating metrics fails during a scrape, the endpoint still returns the previo
 - Metrics are available at the **job level** only. You won't see per-table breakdowns in this release.
 - This endpoint exposes **metrics only**. Logs and traces are not included.
 - You need to run your own Prometheus and Grafana setup. OLake Go does not ship or manage these for you.
+- `/metrics` covers **sync jobs only**. It does not expose container, host, or Go runtime metrics. For infrastructure monitoring, use [cAdvisor](https://github.com/google/cadvisor) (built into the kubelet on Kubernetes).

--- a/docs/getting-started/metrics.mdx
+++ b/docs/getting-started/metrics.mdx
@@ -11,7 +11,7 @@ OLake Go UI exposes a Prometheus compatible `/metrics` endpoint so you can monit
 This is a **pull based** endpoint, point your existing Prometheus scrape config at it and metrics are available immediately. No agents, sidecars, or additional configuration are required on OLake Go's side.
 
 :::info
-Metrics are scoped at the **job level**, reflecting each job's most recent sync run. Table level metric breakdowns are not available in this release.
+Metrics are scoped at the **job level**, reflecting each job's most recent sync run.
 :::
 
 ## Enabling the Endpoint
@@ -29,7 +29,8 @@ It's controlled by an environment variable on the OLake Go UI service:
 | `METRICS_ENABLED` | `false` | Set to `true` to enable the endpoint. When disabled, `/metrics` returns a `404`. |
 
 :::info
-- To enable the `/metrics` endpoint, add `METRICS_ENABLED=true` under `x-envs` in your Docker Compose file. See [Service Environment Variables](/docs/install/olake-ui/#service-environment-variables) for setup details.
+- **Docker Compose:** <br/> To enable the `/metrics` endpoint, add `METRICS_ENABLED=true` under `x-envs` in your Docker Compose file. See [Service Environment Variables](/docs/install/olake-ui/#service-environment-variables) for setup details.
+- **Helm:** <br/> To enable the `/metrics` endpoint, add `METRICS_ENABLED: true` under `olakeUI` in your `values.yaml` file.
 - Once enabled, metrics will be available from the next sync run. Historical metrics from previous runs are not available.
 :::
 
@@ -42,8 +43,7 @@ The endpoint is **unauthenticated** and sits outside the `/api` route group, so 
 These metrics show what's happening with your latest sync for each job. Think of them as a dashboard that updates with fresh numbers every time a new sync starts or completes. When a new sync begins, it replaces the previous sync's numbers.
 
 :::note
-- Clear-destination runs are not included in these metrics. Only regular sync operations are tracked.
-- The endpoint exposes only the `olake_*` series listed below (plus the scrape-error counter). The default `go_*` and `process_*` runtime metrics are intentionally not included.
+The endpoint exposes only the `olake_*` series listed below (plus the scrape-error counter). The default `go_*` and `process_*` runtime metrics are intentionally not included.
 :::
 
 | Metric | Description |
@@ -87,7 +87,7 @@ Each scrape derives its response from three sources, refreshed independently:
 3. **Records, bytes, CPU, and memory**: read from the sync process's `stats.json` on the shared volume, refreshed at most every 2 seconds.
 
 :::info
-If a refresh fails during a scrape, the endpoint serves the previous values instead of erroring, and increments a `olake_metrics_scrape_errors_total` counter so scrape failures are still trackable.
+If a stats file scapre fails, the endpoint serves the previous values instead of erroring, and increments `olake_metrics_scrape_errors_total` on each failure. Stats refresh every 2 seconds, so this counter shows how stale the served metrics are for example, a count of `3` means the values are roughly 6 seconds old.
 :::
 
 ## Stats Freshness

--- a/docs/getting-started/metrics.mdx
+++ b/docs/getting-started/metrics.mdx
@@ -29,7 +29,8 @@ It's controlled by an environment variable on the OLake Go UI service:
 | `METRICS_ENABLED` | `false` | Set to `true` to enable the endpoint. When disabled, `/metrics` returns a `404`. |
 
 :::info
-To enable the `/metrics` endpoint, add `METRICS_ENABLED=true` under `x-envs` in your Docker Compose file. See [Service Environment Variables](/docs/install/olake-ui/#service-environment-variables) for setup details.
+- To enable the `/metrics` endpoint, add `METRICS_ENABLED=true` under `x-envs` in your Docker Compose file. See [Service Environment Variables](/docs/install/olake-ui/#service-environment-variables) for setup details.
+- Once enabled, metrics will be available from the next sync run. Historical metrics from previous runs are not available.
 :::
 
 The endpoint is **unauthenticated** and sits outside the `/api` route group, so your Prometheus scraper doesn't need OLake Go UI credentials to reach it.
@@ -89,10 +90,23 @@ Each scrape derives its response from three sources, refreshed independently:
 If a refresh fails during a scrape, the endpoint serves the previous values instead of erroring, and increments a `olake_metrics_scrape_errors_total` counter so scrape failures are still trackable.
 :::
 
+## Stats Freshness
+
+Changes reach Prometheus with a maximum delay of **snapshot cadence + scrape interval** (plus approximately 1 second Temporal lag):
+
+- **Snapshot cadence**: OLake's internal refresh schedule that captures the current state. Status and duration metrics refresh every 10 seconds. Throughput metrics (records, bytes, CPU, memory) refresh every 2 seconds.
+- **Scrape interval**: The frequency at which Prometheus scrapes the `/metrics` endpoint, configured in the Prometheus scrape config.
+
+**Visibility timeline:**
+
+- **New job**: Snapshot cadence is 10 seconds. Jobs that haven't run yet won't appear.
+- **Completion or cancellation**: Snapshot cadence is 10 seconds.
+- **Granularity**: Snapshot cadence is 2 seconds for throughput metrics (records, bytes, CPU, memory) and 10 seconds for status and duration metrics.
+
 ## Limitations
 
 - Metrics show only the **latest** sync run for each job. When a new sync starts, it replaces the numbers from the previous run.
-- Metrics are available at the **job level** only. You won't see per-table breakdowns in this release.
+- Metrics are available at the **job level** only. You won't see per-table breakdowns.
 - This endpoint exposes **metrics only**. Logs and traces are not included.
-- You need to run your own Prometheus and Grafana setup. OLake Go does not ship or manage these for you.
+- Prometheus and its compatible visualization tools require separate setup. OLake Go **does not** bundle or manage these tools.
 - `/metrics` covers **sync jobs only**. It does not expose container, host, or Go runtime metrics. For infrastructure monitoring, use [cAdvisor](https://github.com/google/cadvisor) (built into the kubelet on Kubernetes).

--- a/docs/getting-started/metrics.mdx
+++ b/docs/getting-started/metrics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Metrics
-description: Expose OLake sync and system metrics on a Prometheus-compatible `/metrics` endpoint for monitoring in Grafana and other tools.
+description: Expose OLake Go sync and system metrics on a Prometheus-compatible `/metrics` endpoint for monitoring in Grafana and other tools.
 sidebar_position: 4
 ---
 
@@ -9,6 +9,10 @@ sidebar_position: 4
 OLake Go UI exposes a Prometheus compatible `/metrics` endpoint so you can monitor the health and performance of your sync jobs using standard tooling like Grafana, without parsing logs manually.
 
 This is a **pull based** endpoint, point your existing Prometheus scrape config at it and metrics are available immediately. No agents, sidecars, or additional configuration are required on OLake Go's side.
+
+:::note Version Requirements
+To use the `/metrics` endpoint, upgrade **OLake UI** to version **0.X.X** or higher.
+:::
 
 :::info
 Metrics are scoped at the **job level**, reflecting each job's most recent sync run.
@@ -94,7 +98,7 @@ If a stats file scapre fails, the endpoint serves the previous values instead of
 
 Changes reach Prometheus with a maximum delay of **snapshot cadence + scrape interval** (plus approximately 1 second Temporal lag):
 
-- **Snapshot cadence**: OLake's internal refresh schedule that captures the current state. Status and duration metrics refresh every 10 seconds. Throughput metrics (records, bytes, CPU, memory) refresh every 2 seconds.
+- **Snapshot cadence**: OLake Go's internal refresh schedule that captures the current state. Status and duration metrics refresh every 10 seconds. Throughput metrics (records, bytes, CPU, memory) refresh every 2 seconds.
 - **Scrape interval**: The frequency at which Prometheus scrapes the `/metrics` endpoint, configured in the Prometheus scrape config.
 
 **Visibility timeline:**

--- a/docs/install/docker-cli.mdx
+++ b/docs/install/docker-cli.mdx
@@ -262,17 +262,28 @@ This command is executed when a sync needs to be run in Full Refresh mode or whe
 The `stats.json` file is created as soon as the sync starts. The file looks like this:
 
 ```json title="stats.json"
-{"Estimated Remaining Time": "1642.00","Memory": "2228 mb","Running Threads": 21,"Seconds Elapsed": "186.00","Speed": "76542.20 rps","Synced Records": 14236868}
+{
+  "Writer Threads": 21,
+  "Synced Records": 14236868,
+  "Bytes Read": 9876543210,
+  "Speed": "76542.20 rps",
+  "Seconds Elapsed": "186.00",
+  "Estimated Remaining Time": "1642.00 s",
+  "Memory Usage Bytes": 2335248384,
+  "CPU Utilization": 0.9348
+}
 ```
 
 | Componenet                   | Example Value  | Description                                                                     |
 |------------------------------|----------------|---------------------------------------------------------------------------------|
 | **Estimated Remaining Time** | `1642.00`      | A rough estimation in seconds, indicating when the sync is expected to complete |
-| **Memory**                   | `2228 mb`      | Memory which is currently getting utilizied                                     |
-| **Running Threads**          | `21`           | Number of parallel threads actively syncing data                                |
+| **Memory Usage Bytes**       | `2335248384`   | System memory currently in use, reported in bytes                               |
+| **Writer Threads**           | `21`           | Number of parallel writer threads actively syncing data                         |
 | **Seconds Elapsed**          | `186.00`       | Time in seconds elapsed since the sync started                                  |
 | **Speed**                    | `76542.20 rps` | How many rows per second are being synced in this sync.                         |
 | **Synced Records**           | `14236868`     | Total number of records which have been synced since the sync started.          |
+| **Bytes Read**               | `9876543210`   | Total source bytes read and committed to the destination since the sync started |
+| **CPU Utilization**          | `0.9348`       | CPU usage during the sync, reported as a decimal ratio (for example, `0.9348` is about 93.48%) |
 
 
 The `stats.json` file remains available after sync completion. 

--- a/docs/install/kubernetes.mdx
+++ b/docs/install/kubernetes.mdx
@@ -570,7 +570,8 @@ olakeUI:
   #   env:
   #     CUSTOM_VAR: "value"
   #     FEATURE_FLAG: "true"
-  env: { METRICS_ENABLED: true }
+  env:
+    METRICS_ENABLED: "true"
 ```
 
 Once enabled, Prometheus can scrape `http://<your-olake-host>:8000/metrics`. For available metrics and scrape behavior, see [Metrics](/docs/getting-started/metrics/).

--- a/docs/install/kubernetes.mdx
+++ b/docs/install/kubernetes.mdx
@@ -557,6 +557,24 @@ global:
     linkerd.io/inject: enabled
 ```
 
+### Prometheus Metrics Configuration
+
+To expose OLake Go's Prometheus compatible `/metrics` endpoint, enable it in your `values.yaml` under `olakeUI.env`:
+
+```yaml
+# values.yaml
+olakeUI:
+  # -- Environment variables for OLake UI
+  # Add custom environment variables here
+  # Example:
+  #   env:
+  #     CUSTOM_VAR: "value"
+  #     FEATURE_FLAG: "true"
+  env: { METRICS_ENABLED: true }
+```
+
+Once enabled, Prometheus can scrape `http://<your-olake-host>:8000/metrics`. For available metrics and scrape behavior, see [Metrics](/docs/getting-started/metrics/).
+
 ## Troubleshooting
 
 ### Check Pod Logs

--- a/docs/install/olake-ui/index.mdx
+++ b/docs/install/olake-ui/index.mdx
@@ -342,6 +342,22 @@ services:
 
 The retention period is specified in **hours**. Only job and sync history within the configured retention period will be visible in the OLake UI.
 
+### Prometheus Metrics Configuration
+
+To expose OLake Go's Prometheus compatible `/metrics` endpoint, add `METRICS_ENABLED: true` under `x-envs.shared` in your `docker-compose.yml` file:
+
+```yaml
+x-envs:
+  shared: &sharedEnvs
+    CONTAINER_REGISTRY_BASE: ${CONTAINER_REGISTRY_BASE:-registry-1.docker.io}
+    OLAKE_SECRET_KEY: *encryptionKey
+    PERSISTENT_DIR: *hostPersistencePath
+    ENABLE_OPTIMIZATION: ${ENABLE_OPTIMIZATION:-false}
+    METRICS_ENABLED: true
+```
+
+Once enabled, Prometheus can scrape `http://<your-olake-host>:8000/metrics`. For available metrics and scrape behavior, see [Metrics](/docs/getting-started/metrics/).
+
 ## Troubleshooting
 
 ### Common Issues

--- a/sidebars.js
+++ b/sidebars.js
@@ -111,6 +111,7 @@ const docSidebar = {
         { type: 'doc', id: 'getting-started/job-level-properties', label: 'Job-level Properties' },
         { type: 'doc', id: 'understanding/terminologies/olake', label: 'Stream-level Properties' },
         { type: 'doc', id: 'getting-started/alerts-and-notifications', label: 'Alerts & Notifications' },
+        { type: 'doc', id: 'getting-started/metrics', label: 'Metrics' },
       ],
     },
 


### PR DESCRIPTION
Adds documentation for the OLake Go UI Prometheus `/metrics` endpoint and updates the `stats.json` field reference for bytes read, CPU utilisation.