### PR TITLE
docs: update release notes olake go

### DIFF
--- a/docs/release/ingestion/v0.9.0.mdx
+++ b/docs/release/ingestion/v0.9.0.mdx
@@ -1,0 +1,32 @@
+---
+title: "OLake Go (v0.9.0)"
+---
+
+# OLake Go (v0.9.0)
+July 12, 2026 – July 24, 2026
+
+## 🎯 What's New
+
+### Platform Features
+
+1. **OLake Go version in startup logs -** <br/> Added OLake Go version logging during application startup so the running version is immediately visible in the logs. This makes it easier to verify deployments, troubleshoot issues, and confirm the exact OLake Go version running in an environment.
+
+2. **Faster integration test startup -** <br/> Updated the OLake Go Docker image to use a shared custom base image across all drivers, reducing the time required to spawn fresh driver containers during integration tests. This speeds up test execution and improves the development workflow.
+
+3. **Simplified local development and testing -** <br/> Added new `make` targets to simplify local development and testing. Contributors can now start test databases, build drivers, and run integration, two-phase commit, and unit tests using the same workflow as CI, making it easier to set up a development environment and ensure consistent test execution.
+
+4. **Enhanced sync statistics -** <br/> Expanded `stats.json` to report both the number of records and the total source bytes processed during a sync, providing better visibility into data movement and sync performance. Metrics are now accurately tracked across retries to prevent overcounting, and CPU usage is included to help monitor sync performance.
+
+### Catalogs
+
+1. **Google BigLake catalog support -** <br/> Upgraded Apache Iceberg to v1.10.2, adding support for the Google BigLake catalog. Now we can configure BigLake catalogs directly from OLake Go, including the required Google authentication and catalog settings.
+
+### Destinations
+
+1. **Rolling file writes for the S3 destination -** <br/> Added rolling file writes for the S3 destination, allowing large partitions to be written as multiple size-bounded files instead of a single output file. This reduces memory usage during syncs and produces more manageable output files for large datasets.
+
+## 🔧 Bug Fixes & Stability
+
+1. **Preserved record order during concurrent filtering -** <br/> Fixed an issue where records could be processed out of order during concurrent filtering, potentially resulting in out-of-order CDC events. Filtering now preserves the original record order while retaining the performance benefits of concurrent evaluation.
+
+2. **Improved integration test reliability -** <br/> Fixed an issue where stale Iceberg writer processes could prevent subsequent integration tests from starting, causing port conflicts between test runs. Test environments now clean up leaked processes correctly, ensuring reliable sequential test execution.

--- a/sidebars.js
+++ b/sidebars.js
@@ -158,6 +158,7 @@ const docSidebar = {
       type: 'category',
       label: 'Versions',
       items: [
+        'release/ingestion/v0.9.0',
         'release/ingestion/v0.8.0',
         'release/ingestion/v0.7.0',
         'release/ingestion/v0.6.0',


### PR DESCRIPTION
updated the release notes of olake go with v0.9.0