### PR TITLE
Redirected the old 404 page to the closest working slug

### DIFF
--- a/customer-stories/2026-02-11-lendingkart-data-correctness.mdx
+++ b/customer-stories/2026-02-11-lendingkart-data-correctness.mdx
@@ -2,7 +2,7 @@
 title: "Reliable Lakehouse Ingestion at Scale: How LendingKart Improved Data Correctness and Compressed Lake Ingestion Volume by 100×"
 description: "How LendingKart reduced daily MongoDB data movement from gigabytes to megabytes while completing an 11 years historical backfill that their Debezium + Spark setup couldn't deliver reliably."
 authors: [prasanna, ankit-lendingkart, abhishek-sinha]
-slug: lendingkart-Improved-Data-Correctness
+slug: lendingkart-improved-data-correctness
 tags: [customer-stories,b2b,lakehouse,mongodb,delta-lake,cdc,spark,kubernetes]
 image: /img/customers/lendingkart/cover-image-lendingkart.webp
 date: 2026-02-11

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -770,7 +770,6 @@ const config = {
             to: '/docs/install/docker-cli',
             from: '/docs/install/docker.mdx'
           },
-
           // recent destination doc re-structuring redirects
 
           {
@@ -1106,6 +1105,79 @@ const config = {
           {
             to: 'https://github.com/datazip-inc/olake',
             from: '/github'
+          },
+
+          // 404 re-directs
+          
+          // OLake Go docs
+          {
+            to: '/docs/install/olake-ui/',
+            from: '/docs/install/'
+          },
+          {
+            to: '/docs/writers/iceberg/catalog/glue/',
+            from: ['/docs/writers/', '/docs/writers/iceberg/catalog']
+          },
+          {
+            to: '/docs/writers/parquet/config/',
+            from: '/docs/writers/parquet/'
+          },
+          {
+            to: '/docs/core/architecture/',
+            from: '/docs/core/'
+          },
+          {
+            to: '/docs/understanding/compatibility-catalogs/',
+            from: '/docs/understanding/'
+          },
+          {
+            to: '/docs/api/olake-ui-api/',
+            from: '/docs/api/'
+          },
+          {
+            to: '/docs/community/contributing/',
+            from: '/docs/community/'
+          },
+          {
+            to: '/docs/release/ingestion/overview/',
+            from: ['/docs/release/ingestion/', '/docs/release/']
+          },
+          {
+            to: '/docs/understanding/terminologies/general/',
+            from: '/docs/understanding/terminologies/'
+          },
+          // OLake Fusion docs
+          {
+            to: '/docs/fusion/getting-started/overview/',
+            from: ['/docs/fusion/getting-started/', '/docs/fusion/']
+          },
+          {
+            to: '/docs/fusion/install/olake-ui/',
+            from: '/docs/fusion/install/'
+          },
+          {
+            to: '/docs/fusion/maintenance/catalogs/',
+            from: '/docs/fusion/maintenance/'
+          },
+          {
+            to: '/docs/fusion/compaction/types-of-compaction/',
+            from: '/docs/fusion/compaction/'
+          },
+          {
+            to: '/docs/fusion/core/architecture/',
+            from: '/docs/fusion/core/'
+          },
+          {
+            to: '/docs/fusion/core/compatibility/query-engines/',
+            from: '/docs/fusion/core/compatibility/'
+          },
+          {
+            to: '/docs/fusion/community/contributing/',
+            from: '/docs/fusion/community/'
+          },
+          {
+            to: '/docs/fusion/release/maintenance/overview/',
+            from: ['/docs/fusion/release/maintenance/', '/docs/fusion/release/']
           }
         ]
       }


### PR DESCRIPTION
Added redirects for pages returning 404 errors, routing each broken URL to the closest relevant working slug. This helps preserve existing links, improves user experience, and reduces dead-end navigation.