### PR TITLE
chore: gitignore local Claude Code tooling state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-.vscode/
+.vscode/.cocoindex_code/
+CLAUDE.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-.vscode/.cocoindex_code/
+.vscode/
+.cocoindex_code/
 CLAUDE.local.md


### PR DESCRIPTION
Adds `.cocoindex_code/` (local semantic-search index/settings) and `CLAUDE.local.md` (personal Claude Code agent instructions) to .gitignore.

These are machine-local dev tooling artifacts (Claude Code + cocoindex-code + Graphiti setup) — not meant to be shared/tracked. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)