### PR TITLE
docs: Update prometheus docs

### DIFF
--- a/docs/install/kubernetes.mdx
+++ b/docs/install/kubernetes.mdx
@@ -574,7 +574,7 @@ olakeUI:
     METRICS_ENABLED: "true"
 ```
 
-Once enabled, Prometheus can scrape `http://<your-olake-host>:8000/metrics`. For available metrics and scrape behavior, see [Metrics](/docs/getting-started/metrics/).
+Once enabled, Prometheus can scrape `http://<your-olake-host>:8000/metrics`. For available metrics and scrape behavior, see [Prometheus Integration](/docs/monitoring-and-observability/metrics/).
 
 ## Troubleshooting
 

--- a/docs/install/olake-ui/index.mdx
+++ b/docs/install/olake-ui/index.mdx
@@ -356,7 +356,7 @@ x-envs:
     METRICS_ENABLED: true
 ```
 
-Once enabled, Prometheus can scrape `http://<your-olake-host>:8000/metrics`. For available metrics and scrape behavior, see [Metrics](/docs/getting-started/metrics/).
+Once enabled, Prometheus can scrape `http://<your-olake-host>:8000/metrics`. For available metrics and scrape behavior, see [Prometheus Integration](/docs/monitoring-and-observability/metrics/).
 
 ## Troubleshooting
 

--- a/docs/monitoring-and-observability/metrics.mdx
+++ b/docs/monitoring-and-observability/metrics.mdx
@@ -1,10 +1,10 @@
 ---
-title: Metrics
+title: Prometheus Integration
 description: Expose OLake Go sync and system metrics on a Prometheus-compatible `/metrics` endpoint for monitoring in Grafana and other tools.
 sidebar_position: 4
 ---
 
-# Metrics
+# Prometheus Integration
 
 OLake Go UI exposes a Prometheus compatible `/metrics` endpoint so you can monitor the health and performance of your sync jobs using standard tooling like Grafana, without parsing logs manually.
 
@@ -42,7 +42,7 @@ The endpoint is **unauthenticated** and sits outside the `/api` route group, so 
 
 ## Metrics Specification
 
-### 1. Sync metrics
+### 1. Sync Metrics
 
 These metrics show what's happening with your latest sync for each job. Think of them as a dashboard that updates with fresh numbers every time a new sync starts or completes. When a new sync begins, it replaces the previous sync's numbers.
 
@@ -67,7 +67,7 @@ Every sync metric carries the following labels:
 | `source_name` | Source name configured by the user. |
 | `destination_name` | Destination name configured by the user. |
 
-### 2. System metrics
+### 2. System Metrics
 
 | Metric | Description |
 | --- | --- |

--- a/sidebars.js
+++ b/sidebars.js
@@ -111,9 +111,12 @@ const docSidebar = {
         { type: 'doc', id: 'getting-started/job-level-properties', label: 'Job-level Properties' },
         { type: 'doc', id: 'understanding/terminologies/olake', label: 'Stream-level Properties' },
         { type: 'doc', id: 'getting-started/alerts-and-notifications', label: 'Alerts & Notifications' },
-        { type: 'doc', id: 'getting-started/metrics', label: 'Metrics' },
       ],
     },
+
+    // MONITORING AND OBSERVABILITY
+    sectionHeader("MONITORING AND OBSERVABILITY"),
+    { type: 'doc', id: 'monitoring-and-observability/metrics', label: 'Prometheus Integration' },
 
     // CORE CONCEPTS
     sectionHeader("CORE CONCEPTS"),


### PR DESCRIPTION
Created a new tab named Monitoring and Observability and under this section now we have the Prometheus Integration. 
 