### PR TITLE
docs: update prometheus

### DIFF
--- a/docs/monitoring-and-observability/metrics.mdx
+++ b/docs/monitoring-and-observability/metrics.mdx
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 # Prometheus Integration
 
-OLake Go UI exposes a Prometheus compatible `/metrics` endpoint so you can monitor the health and performance of your sync jobs using standard tooling like Grafana, without parsing logs manually.
+OLake UI exposes a Prometheus compatible `/metrics` endpoint so you can monitor the health and performance of your sync jobs using standard tooling like Grafana, without parsing logs manually.
 
 This is a **pull based** endpoint, point your existing Prometheus scrape config at it and metrics are available immediately. No agents, sidecars, or additional configuration are required on OLake Go's side.
 
@@ -20,13 +20,13 @@ Metrics are scoped at the **job level**, reflecting each job's most recent sync 
 
 ## Enabling the Endpoint
 
-The `/metrics` endpoint is served by the OLake Go UI backend on the same port as the UI itself at:
+The `/metrics` endpoint is served by the OLake UI backend on the same port as the UI itself at:
 
 ```
 GET http://<your-olake-host>:8000/metrics
 ```
 
-It's controlled by an environment variable on the OLake Go UI service:
+It's controlled by an environment variable on the OLake UI service:
 
 | Variable | Default | Description |
 | --- | --- | --- |
@@ -38,7 +38,7 @@ It's controlled by an environment variable on the OLake Go UI service:
 - Once enabled, metrics will be available from the next sync run. Historical metrics from previous runs are not available.
 :::
 
-The endpoint is **unauthenticated** and sits outside the `/api` route group, so your Prometheus scraper doesn't need OLake Go UI credentials to reach it.
+The endpoint is **unauthenticated** and sits outside the `/api` route group, so your Prometheus scraper doesn't need OLake UI credentials to reach it.
 
 ## Metrics Specification
 
@@ -52,7 +52,7 @@ The endpoint exposes only the `olake_*` series listed below (plus the scrape-err
 
 | Metric | Description |
 | --- | --- |
-| `olake_sync_status` | Status of the latest sync run: <br/> `0` = running (a paused run also reports `0`) <br/> `1` = succeeded <br/> `2` = failed (a cancelled sync is also reported as failed). |
+| `olake_sync_status` | Status of the latest sync run: <br/> `0` = running <br/> `1` = succeeded <br/> `2` = failed (a cancelled sync is also reported as failed). |
 | `olake_sync_start_time_seconds` | Unix timestamp of when the latest sync run started. |
 | `olake_sync_duration_seconds` | Duration of the run in seconds. Updates live while the sync is running, and freezes once it completes. |
 | `olake_sync_records_ingested` | Total records ingested during the run. |
@@ -113,4 +113,5 @@ Changes reach Prometheus with a maximum delay of **snapshot cadence + scrape int
 - Metrics are available at the **job level** only. You won't see per-table breakdowns.
 - This endpoint exposes **metrics only**. Logs and traces are not included.
 - Prometheus and its compatible visualization tools require separate setup. OLake Go **does not** bundle or manage these tools.
+- The `/metrics` endpoint is available in **OLake UI** only. It is **not** supported for CLI-based deployments.
 - `/metrics` covers **sync jobs only**. It does not expose container, host, or Go runtime metrics. For infrastructure monitoring, use [cAdvisor](https://github.com/google/cadvisor) (built into the kubelet on Kubernetes).


### PR DESCRIPTION
Remove the pause job mention from prometheus docs and mention that this feature is not available in CLI