### PR TITLE
docs: Update release notes OLake Go 

### DIFF
--- a/docs/release/ingestion/v0.9.0.mdx
+++ b/docs/release/ingestion/v0.9.0.mdx
@@ -33,7 +33,7 @@ July 12, 2026 – Aug 11, 2026
 
 ### Monitoring and Observability
 
-1. **Prometheus metrics for OLake UI -** <br/> Added a Prometheus `/metrics` endpoint to the OLake UI, exposing sync metrics such as sync status, duration, records ingested, bytes read, CPU usage, and memory usage. This enables users to monitor OLake Go syncs metrics through Prometheus.
+1. **Metrics Endpoint for Prometheus -** <br/> Added a Prometheus `/metrics` endpoint to the OLake UI, exposing sync metrics such as sync status, duration, records ingested, bytes read, CPU usage, and memory usage. This enables users to monitor OLake Go syncs metrics through Prometheus.
 
 ## 🔧 Bug Fixes & Stability
 

--- a/docs/release/ingestion/v0.9.0.mdx
+++ b/docs/release/ingestion/v0.9.0.mdx
@@ -25,11 +25,15 @@ July 12, 2026 – Aug 11, 2026
 
 1. **Google BigLake catalog support -** <br/> Upgraded Apache Iceberg to v1.10.2, adding support for the Google BigLake catalog. Now we can configure BigLake catalogs directly from OLake Go, including the required Google authentication and catalog settings.
 
-2. **BigLake Multi-Bucket catalog support -** <br/> Extended BigLake catalog support to enable OLake Go to write data to BigLake multi-bucket catalogs. Added the required GCP project configuration to ensure requests are correctly routed through the BigLake catalog.
+2. **Google BigLake Multi-Bucket catalog support -** <br/> Extended BigLake catalog support to enable OLake Go to write data to BigLake multi-bucket catalogs. Added the required GCP project configuration to ensure requests are correctly routed through the BigLake catalog.
 
 ### Destinations
 
 1. **Rolling file writes for the S3 destination -** <br/> Added rolling file writes for the S3 destination, allowing large partitions to be written as multiple size-bounded files instead of a single output file. This reduces memory usage during syncs and produces more manageable output files for large datasets.
+
+### Monitoring and Observability
+
+1. **Prometheus metrics for OLake UI -** <br/> Added a Prometheus `/metrics` endpoint to the OLake UI, exposing sync metrics such as sync status, duration, records ingested, bytes read, CPU usage, and memory usage. This enables users to monitor OLake Go syncs metrics through Prometheus.
 
 ## 🔧 Bug Fixes & Stability
 

--- a/docs/release/ingestion/v0.9.0.mdx
+++ b/docs/release/ingestion/v0.9.0.mdx
@@ -1,9 +1,9 @@
 ---
-title: "OLake Go (v0.9.0)"
+title: "OLake Go (v0.9.0 - v0.9.1)"
 ---
 
-# OLake Go (v0.9.0)
-July 12, 2026 – July 24, 2026
+# OLake Go (v0.9.0 - v0.9.1)
+July 12, 2026 – Aug 11, 2026
 
 ## 🎯 What's New
 
@@ -17,9 +17,15 @@ July 12, 2026 – July 24, 2026
 
 4. **Enhanced sync statistics -** <br/> Expanded `stats.json` to report both the number of records and the total source bytes processed during a sync, providing better visibility into data movement and sync performance. Metrics are now accurately tracked across retries to prevent overcounting, and CPU usage is included to help monitor sync performance.
 
+5. **Source bytes in telemetry -** <br/> Added source bytes read to OLake Go telemetry, extending the existing sync statistics to report the amount of data processed through telemetry.
+
+6. **Decoupled integration test dependencies -** <br/> Removed the remaining shared Go dependencies between the integration test suites and the OLake Go product module, allowing the tests to build and run independently. This also keeps test-only dependencies from affecting OLake Go driver builds and simplifies dependency management across the project.
+
 ### Catalogs
 
 1. **Google BigLake catalog support -** <br/> Upgraded Apache Iceberg to v1.10.2, adding support for the Google BigLake catalog. Now we can configure BigLake catalogs directly from OLake Go, including the required Google authentication and catalog settings.
+
+2. **BigLake Multi-Bucket catalog support -** <br/> Extended BigLake catalog support to enable OLake Go to write data to BigLake multi-bucket catalogs. Added the required GCP project configuration to ensure requests are correctly routed through the BigLake catalog.
 
 ### Destinations
 
@@ -30,3 +36,19 @@ July 12, 2026 – July 24, 2026
 1. **Preserved record order during concurrent filtering -** <br/> Fixed an issue where records could be processed out of order during concurrent filtering, potentially resulting in out-of-order CDC events. Filtering now preserves the original record order while retaining the performance benefits of concurrent evaluation.
 
 2. **Improved integration test reliability -** <br/> Fixed an issue where stale Iceberg writer processes could prevent subsequent integration tests from starting, causing port conflicts between test runs. Test environments now clean up leaked processes correctly, ensuring reliable sequential test execution.
+
+3. **Decoupled integration test framework -** <br/> Moved the integration test framework into a separate module, decoupling it from the main OLake Go codebase. This simplifies driver dependencies and allows integration tests to be built and run independently.
+
+4. **S3 Parquet data type compatibility -** <br/> Fixed data type conversions in the S3 Parquet parser to ensure schemas and values are consistent with OLake Go's database drivers. This fixes issues with timestamp precision, numeric types, unsigned integers, UUIDs, and legacy timestamps, preventing data loss, overflow, and incorrect destination schemas.
+
+5. **Java dependency vulnerability scanning -** <br/> Added Trivy-based vulnerability scanning for the Java Iceberg writer to detect known HIGH and CRITICAL security vulnerabilities during CI. This improves security coverage for the Java dependencies used by OLake Go.
+
+6. **Lint coverage for all driver modules -** <br/> Expanded CI linting to cover all OLake Go driver modules, ensuring code quality issues are detected across the entire product codebase. Existing lint findings across the drivers have also been resolved, keeping driver builds consistent with the project's linting standards.
+
+7. **JVM trust store synchronization -** <br/> Fixed an issue where custom CA certificates added to the OS trust store were not available to the JVM, causing TLS connections to internal REST catalogs, Hive metastores, and self-signed S3 endpoints to fail. The JVM trust store now stays synchronized with the OS trust store, ensuring consistent certificate handling across OLake Go components.
+
+8. **PostgreSQL CDC support for read replicas -** <br/> Fixed an issue that prevented PostgreSQL CDC from running against read replicas because the driver attempted to read the current WAL position using a primary-only function. The driver now uses the replica's WAL replay position when running in recovery mode, enabling CDC on PostgreSQL read replicas while preserving existing behavior on primary instances.
+
+9. **Improved Iceberg destination configuration -** <br/> Updated the Iceberg destination to provide catalog-specific configuration fields for Lakekeeper, Nessie, S3 Tables, Unity, Polaris, and BigLake. Authentication options and related settings are now shown based on the selected catalog, with catalog-specific configurations automatically applied to simplify destination setup.
+
+10. **Size-based gRPC batching -** <br/> Added size-based batching for gRPC requests, allowing records to be grouped based on batch size rather than using a fixed number of records. This provides more consistent control over the amount of data sent in each batch.

--- a/docs/shared/config/LakekeeperIcebergWriterCLIConfigDetails.jsx
+++ b/docs/shared/config/LakekeeperIcebergWriterCLIConfigDetails.jsx
@@ -16,7 +16,7 @@ const FIELDS = [
     authTypes: AUTH_COMMON,
     parameter: 'catalog_type',
     required: true,
-    sample: 'rest',
+    sample: 'lakekeeper',
     description:
       'Defines the catalog type used by the writer.',
   },

--- a/docs/shared/config/NessieIcebergWriterCLIConfigDetails.jsx
+++ b/docs/shared/config/NessieIcebergWriterCLIConfigDetails.jsx
@@ -37,7 +37,7 @@ const FIELDS = [
     authTypes: AUTH_COMMON,
     parameter: 'catalog_type',
     required: true,
-    sample: 'rest',
+    sample: 'nessie',
     description:
       'Defines the catalog type used by the writer.',
   },

--- a/docs/shared/config/PolarisIcebergWriterCLIConfigDetails.jsx
+++ b/docs/shared/config/PolarisIcebergWriterCLIConfigDetails.jsx
@@ -11,6 +11,15 @@ const AUTH_COMMON = [AUTH_OAUTH2, AUTH_TOKEN];
 
 const FIELDS = [
   {
+    id: 'catalog-type',
+    authTypes: AUTH_COMMON,
+    parameter: 'catalog_type',
+    required: true,
+    sample: 'polaris',
+    description:
+      'Defines the catalog type used by the writer.',
+  },
+  {
     id: 'rest-catalog-url',
     authTypes: AUTH_COMMON,
     parameter: 'rest_catalog_url',

--- a/docs/shared/config/UnityIcebergWriterCLIConfigDetails.jsx
+++ b/docs/shared/config/UnityIcebergWriterCLIConfigDetails.jsx
@@ -14,7 +14,7 @@ const FIELDS = [
     authTypes: AUTH_ALL,
     parameter: 'catalog_type',
     required: true,
-    sample: 'rest',
+    sample: 'unity',
     description:
       'Defines the catalog type used by the writer.',
   },

--- a/docs/writers/iceberg/catalog/rest.mdx
+++ b/docs/writers/iceberg/catalog/rest.mdx
@@ -947,7 +947,7 @@ S3 Tables requires **SigV4** authentication for REST catalog requests. This is m
       **S3 Tables Configuration Parameters**
       | Parameter        | Sample Value                               | Description                                                                                                    |
       |------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-      | **catalog_type**  <br/> `required`   | `rest`                        | Defines the catalog type used by the writer. "rest" means the writer interacts with a RESTful catalog service. |
+      | **catalog_type**  <br/> `required`   | `s3tables`                        | Defines the catalog type used by the writer. "rest" means the writer interacts with a RESTful catalog service. |
       | **rest_catalog_url** <br/> `required`| `https://s3tables.<REGION>.amazonaws.com/iceberg` |   Specifies the endpoint URL for the S3 Tables REST catalog service.                                         |
       | **iceberg_s3_path**  <br/> `required`| `arn:aws:s3tables:<REGION>:<ACCOUNT_ID>:bucket/<BUCKET_NAME>` | ARN of your S3 Tables table bucket. Acts as the warehouse identifier for the REST catalog. The namespaces and tables are created within this bucket.                                                |
       | **aws_region**  <br/> `required`     | `ap-south-1`                                   | Specifies the AWS region associated with the S3 tables bucket where the data is stored.                                                          |
@@ -1666,7 +1666,7 @@ networks:
 {
   "type": "ICEBERG",
   "writer": {
-        "catalog_type": "rest",
+        "catalog_type": "biglake",
         "rest_catalog_url": "https://biglake.googleapis.com/iceberg/v1/restcatalog",
         "catalog_name": "olake_iceberg",
         "iceberg_s3_path": "gs://<BUCKET_NAME>",
@@ -1681,7 +1681,7 @@ networks:
     **BigLake Configuration Parameters**
       | Parameter        | Sample Value                               | Description                                                                                                    |
       |------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-      | **catalog_type**  <br/> `required`   | `rest`                        | Defines the catalog type used by the writer. "rest" means the writer interacts with a RESTful catalog service. |
+      | **catalog_type**  <br/> `required`   | `biglake`                        | Defines the catalog type used by the writer. |
       | **rest_catalog_url** <br/> `required`| `https://biglake.googleapis.com/iceberg/v1/restcatalog` | Endpoint URL for the Google Cloud BigLake REST catalog service.                                         |
       | **iceberg_s3_path**  <br/> `required`| **Single-bucket catalog:**<br/>`gs://<BUCKET_NAME>` <br/><br/>**Multiple-bucket catalog:**<br/>`bl://projects/<PROJECT_ID>/catalogs/<CATALOG_ID>`  | BigLake catalog path to use, OLake Go uses this to look up the storage configuration (e.g. Cloud Storage buckets) already defined in BigLake.<br/><br/>**Single-bucket catalog:** This configuration restricts your catalog to a single bucket and locks the catalog name to the bucket name. <br/><br/>**Multiple-bucket catalog:** This configuration lets your catalog associate multiple buckets and lets you name your catalog independently of any bucket name.                                                |
       | **rest_auth_type** <br/> `required`| `org.apache.iceberg.gcp.auth.GoogleAuthManager` | Iceberg authentication manager for Google Cloud OAuth. BigLake supports only this auth type.                                                                          |


### PR DESCRIPTION
- Updated the release notes for OLake Go v0.9.1
- updated some tables in REST catalog with new catalog_type name for individual catalog.