### PR TITLE
docs: Update release notes OLake Go

### DIFF
--- a/docs/release/ingestion/v0.9.0.mdx
+++ b/docs/release/ingestion/v0.9.0.mdx
@@ -1,11 +1,15 @@
 ---
-title: "OLake Go (v0.9.0 - v0.9.1)"
+title: "OLake Go (v0.9.0 - v0.9.2)"
 ---
 
-# OLake Go (v0.9.0 - v0.9.1)
-July 12, 2026 – Aug 11, 2026
+# OLake Go (v0.9.0 - v0.9.2)
+July 12, 2026 – Aug 13, 2026
 
 ## 🎯 What's New
+
+### Sources
+
+1. **S3 object storage abstraction -** <br/> Refactored the S3 source driver to use a storage-agnostic object store interface instead of directly depending on the AWS SDK. This simplifies testing and lays the groundwork for supporting additional object stores such as GCS and Azure Blob, while preserving existing S3 behavior.
 
 ### Platform Features
 
@@ -20,6 +24,8 @@ July 12, 2026 – Aug 11, 2026
 5. **Source bytes in telemetry -** <br/> Added source bytes read to OLake Go telemetry, extending the existing sync statistics to report the amount of data processed through telemetry.
 
 6. **Decoupled integration test dependencies -** <br/> Removed the remaining shared Go dependencies between the integration test suites and the OLake Go product module, allowing the tests to build and run independently. This also keeps test-only dependencies from affecting OLake Go driver builds and simplifies dependency management across the project.
+
+7. **Integration tests against shipped driver images -** <br/> Updated integration tests to run against the actual OLake driver Docker images, matching the environment and entrypoint used by deployed drivers. This ensures CI validates the shipped driver artifacts, including their runtime dependencies and entrypoint configuration, and catches image-specific regressions that were previously missed.
 
 ### Catalogs
 
@@ -56,3 +62,9 @@ July 12, 2026 – Aug 11, 2026
 9. **Improved Iceberg destination configuration -** <br/> Updated the Iceberg destination to provide catalog-specific configuration fields for Lakekeeper, Nessie, S3 Tables, Unity, Polaris, and BigLake. Authentication options and related settings are now shown based on the selected catalog, with catalog-specific configurations automatically applied to simplify destination setup.
 
 10. **Size-based gRPC batching -** <br/> Added size-based batching for gRPC requests, allowing records to be grouped based on batch size rather than using a fixed number of records. This provides more consistent control over the amount of data sent in each batch.
+
+11. **Fixed Apache HttpClient security vulnerability -** <br/> Updated the Apache HttpClient dependency used by the Iceberg writer to address **CVE-2026-54399**, a denial of service vulnerability caused by excessive HTTP headers. This ensures the Iceberg writer uses a patched version of the underlying HTTP client library.
+
+12. **Fixed last-batch flush handling -** <br/> Fixed an issue where errors during the final batch flush could prevent the commit from being stopped correctly and could be overwritten by subsequent errors. This ensures failures such as schema evolution errors are properly surfaced and prevents records from being silently missed.
+
+13. **MongoDB inline TLS certificate support -** <br/> Fixed MongoDB TLS configuration for UI and Docker deployments by allowing certificates to be provided directly through the connector configuration instead of requiring filesystem paths. This enables secure MongoDB connections in ephemeral environments while preserving support for existing CLI configurations using mounted certificate files.


### PR DESCRIPTION
Updated the release notes for OLake Go with v0.9.2