### PR TITLE
chore: note to upgrade helm chart version to use fusion

### DIFF
--- a/docs/fusion/install/kubernetes-compaction.mdx
+++ b/docs/fusion/install/kubernetes-compaction.mdx
@@ -12,6 +12,10 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 
 This guide details the process for deploying OLake ingestion and Fusion maintenance together on Kubernetes using the official Helm chart. Fusion is installed alongside the core OLake ingestion stack and provides Iceberg table maintenance and ingestion services.
 
+:::info
+If the installed OLake Helm chart is older than **`olake-0.0.15`** (or **`v0.3.4`**), please upgrade to the **latest version** to use Fusion. See [**Upgrading Chart Version**](#upgrading-chart-version) for instructions.
+:::
+
 <details>
 <summary><b>Components & Architecture</b></summary>
 
@@ -209,15 +213,15 @@ global:
   jobServiceAccount:
     create: true
     name: "olake-job-sa"
-    
+
     # Cloud provider IAM role associations
     annotations:
       # AWS IRSA
       eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/olake-job-role"
-      
+
       # GCP Workload Identity
       iam.gke.io/gcp-service-account: "olake-job@project.iam.gserviceaccount.com"
-      
+
       # Azure Workload Identity
       azure.workload.identity/client-id: "12345678-1234-1234-1234-123456789012"
 ```
@@ -295,7 +299,7 @@ For production, a robust, highly-available RWX-capable storage solution such as 
 nfsServer:
   # 1. The development NFS server is disabled
   enabled: false
-  
+
   # 2. An existing ReadWriteMany PersistentVolumeClaim is specified
   external:
     storageClass: "efs-csi"


### PR DESCRIPTION
### Description

Added a note to upgrade the helm chart version to use OLake-Fusion.

<img width="1116" height="355" alt="image" src="https://github.com/user-attachments/assets/652ccfc3-9c7a-4969-a7ae-76606ef682f5" />
