### PR TITLE
docs: Update release note OLake Go

### DIFF
--- a/docs/release/ingestion/v0.9.0.mdx
+++ b/docs/release/ingestion/v0.9.0.mdx
@@ -1,15 +1,17 @@
 ---
-title: "OLake Go (v0.9.0 - v0.9.2)"
+title: "OLake Go (v0.9.0 - v0.9.3)"
 ---
 
-# OLake Go (v0.9.0 - v0.9.2)
-July 12, 2026 – Aug 13, 2026
+# OLake Go (v0.9.0 - v0.9.3)
+July 12, 2026 – Aug 19, 2026
 
 ## 🎯 What's New
 
 ### Sources
 
 1. **S3 object storage abstraction -** <br/> Refactored the S3 source driver to use a storage-agnostic object store interface instead of directly depending on the AWS SDK. This simplifies testing and lays the groundwork for supporting additional object stores such as GCS and Azure Blob, while preserving existing S3 behavior.
+
+2. **XML file support for S3 -** <br/> Added XML file support to the S3 source, allowing OLake Go to ingest `.xml` and `.xml.gz` files.
 
 ### Platform Features
 
@@ -68,3 +70,9 @@ July 12, 2026 – Aug 13, 2026
 12. **Fixed last-batch flush handling -** <br/> Fixed an issue where errors during the final batch flush could prevent the commit from being stopped correctly and could be overwritten by subsequent errors. This ensures failures such as schema evolution errors are properly surfaced and prevents records from being silently missed.
 
 13. **MongoDB inline TLS certificate support -** <br/> Fixed MongoDB TLS configuration for UI and Docker deployments by allowing certificates to be provided directly through the connector configuration instead of requiring filesystem paths. This enables secure MongoDB connections in ephemeral environments while preserving support for existing CLI configurations using mounted certificate files.
+
+14. **Go security updates -** <br/> Updated the Go toolchain from 1.25.12 to 1.25.13 to address five known vulnerabilities in the Go standard library affecting packages including `net/url`, `crypto/tls`, `encoding/xml`, `encoding/asn1`, and `net/http`.
+
+15. **Fixed MySQL unsigned MEDIUMINT values in CDC -** <br/> Fixed an issue where unsigned MySQL `MEDIUMINT` values above 8,388,607 could be interpreted as negative numbers during CDC. Unsigned `MEDIUMINT` values are now correctly preserved when replicated to the destination.
+
+16. **Improved S3 integration test reliability -** <br/> Fixed flaky S3 integration tests that could fail when incremental update files were created within the same second. Added a wait in the test workflow to ensure files are processed reliably while preserving compatibility with existing S3 behavior.


### PR DESCRIPTION
Update release notes for OLake Go with v0.9.3