### PR TITLE
fix: mobile navbar

### DIFF
--- a/src/components/landing/Navbar/SiteNavbar.css
+++ b/src/components/landing/Navbar/SiteNavbar.css
@@ -444,7 +444,7 @@ body:has(.landing-page) .olake-nav [class*='navbarSearchContainer'],
   }
 
   .olake-nav-right {
-    gap: 8px;
+    gap: 5px;
   }
 
   .olake-nav-tagline {
@@ -456,8 +456,14 @@ body:has(.landing-page) .olake-nav [class*='navbarSearchContainer'],
   }
 
   .olake-nav .olake-nav-cta {
-    padding: 9px 14px;
-    font-size: 13px;
+    padding: 7px 12px;
+    font-size: 12px;
+  }
+
+  /* Hide Slack, GitHub, and Talk to us button on mobile navbar header only (not sidebar) */
+  .olake-nav .olake-nav-gh-mobile,
+  .olake-nav-right > .olake-nav-slack {
+    display: none;
   }
 }
 

--- a/src/components/landing/Navbar/SiteNavbar.tsx
+++ b/src/components/landing/Navbar/SiteNavbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type ReactNode } from 'react'
+import React, { useEffect, useRef, useState, type ReactNode } from 'react'
 import Link from '@docusaurus/Link'
 import { useLocation } from '@docusaurus/router'
 import { cn } from '@site/src/lib/utils'
@@ -233,8 +233,21 @@ export default function SiteNavbar({ trailing, mobileSidebar }: SiteNavbarProps)
   const mobileOpen = mobileSidebar ? mobileSidebar.shown : ownOpen
   const toggleMobile = mobileSidebar ? mobileSidebar.toggle : () => setOwnOpen((o) => !o)
 
+  // Measures real height for --ifm-navbar-height (sticky tabs-bar offset, custom.css) instead of guessing per breakpoint.
+  const navRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = navRef.current
+    if (!el) return
+    const setVar = () =>
+      document.documentElement.style.setProperty('--ifm-navbar-height', `${el.offsetHeight}px`)
+    setVar()
+    const observer = new ResizeObserver(setVar)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   return (
-    <div className='olake-nav'>
+    <div className='olake-nav' ref={navRef}>
       <div className='olake-nav-inner'>
         <div className='olake-nav-left'>
           <Link to='/' className='olake-nav-logo'>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1193,6 +1193,8 @@ html[data-theme='dark'] .tabs-container > ul.tabs {
   border-top-left-radius: var(--radius);
   border-top-right-radius: var(--radius);
   margin-bottom: -1px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .tabs-container .tabs__item--active {


### PR DESCRIPTION
- fixes mobile navbar overlapping button issue

Before:
<img width="472" height="93" alt="Screenshot 2026-08-22 at 3 29 26 PM" src="https://github.com/user-attachments/assets/e788096c-7865-4754-9b20-a47145e25c25" />

After:
<img width="443" height="89" alt="Screenshot 2026-08-22 at 3 28 58 PM" src="https://github.com/user-attachments/assets/e901d57a-f22e-43c0-9990-8927ef3dee87" />

- gap between sticky section headers and navbar in mobile

Before:

<img width="433" height="243" alt="Screenshot 2026-08-22 at 3 30 15 PM" src="https://github.com/user-attachments/assets/ec1ee0a3-fe35-4679-8e4f-5f39e0f4cf63" />

After:
<img width="471" height="268" alt="Screenshot 2026-08-22 at 3 30 26 PM" src="https://github.com/user-attachments/assets/deaa5431-ed91-4e54-b2d7-ad28cb7f039e" />

- sticky header overlapping the bottom sticky header issue in mobile

Before:
<img width="440" height="176" alt="Screenshot 2026-08-22 at 3 30 49 PM" src="https://github.com/user-attachments/assets/69edddcc-4b03-413c-922c-44af981db74f" />

After:
<img width="533" height="199" alt="Screenshot 2026-08-22 at 3 31 49 PM" src="https://github.com/user-attachments/assets/57db0c1e-d6bf-463d-8fdf-631e88f13198" />


