### PR TITLE
docs: Update schema evolution doc

### DIFF
--- a/docs/features/schema.mdx
+++ b/docs/features/schema.mdx
@@ -154,13 +154,6 @@ When a column data type is `STRING` and it encounters `NUMERIC` type:
 - Converted values are stored as strings in the destination
 - Pipeline continues without interruption
 
-### Scenario 6: Unsupported Type Change
-
-When the column data type is `INT` and it encounters `FLOAT` or when a `NUMERIC` column encounters a `STRING` type:
-
-- OLake Go detects the type mismatch
-- The write is not allowed and the **sync fails**
-
 For more detailed information on Iceberg's schema evolution capabilities, refer to the [Apache Iceberg documentation](https://iceberg.apache.org/spec/#schema-evolution).
 
 </TabItem>
@@ -239,14 +232,11 @@ When a column widens to `STRING` and incoming values are numeric:
 - Converted values are stored as strings in newly written Parquet files
 - Pipeline continues without interruption
 
-### Scenario 7: Unsupported Type Change
-
-When a column is stored as `STRING` in Parquet and incoming values are `FLOAT64`, `INT64`, or `BOOLEAN`:
-
-- OLake Go detects the type mismatch
-- The write is not allowed and the **sync fails**
-
 </TabItem>
 
 </Tabs>
+
+:::important One-way type conversions
+Type conversions in OLake Go are one-way. When a column is promoted to a wider or more general type for example, `INT` to `BIGINT` in Iceberg, or `BOOLEAN` to `INT32` in Parquet that change is permanent for the column. OLake Go does not support converting back to a narrower or more specific type. Once a column has been widened, all future values must conform to the new type.
+:::
 

--- a/docs/features/schema.mdx
+++ b/docs/features/schema.mdx
@@ -237,6 +237,6 @@ When a column widens to `STRING` and incoming values are numeric:
 </Tabs>
 
 :::important One-way type conversions
-Type conversions in OLake Go are one-way. When a column is promoted to a wider or more general type for example, `INT` to `BIGINT` in Iceberg, or `BOOLEAN` to `INT32` in Parquet that change is permanent for the column. OLake Go does not support converting back to a narrower or more specific type. Once a column has been widened, all future values must conform to the new type.
+Type conversions in OLake Go are one-way. When a column is promoted to a wider or more general type for example, `INT` to `BIGINT` in Iceberg, or `BOOLEAN` to `INT32` in Parquet that change is permanent for the column. OLake Go does not support converting back to a narrower or more specific type. Once a column has been widened, all future values are written using the widened column type only.
 :::
 

--- a/docs/features/schema.mdx
+++ b/docs/features/schema.mdx
@@ -45,70 +45,60 @@ Schema evolution refers to changes in your database structure like adding, remov
 
 Schema data type changes refer to modifications to the data type of existing columns (e.g., changing `INT` to `BIGINT`). OLake Go leverages `Apache Iceberg v2` tables' type promotion capabilities to handle compatible changes automatically.
 
-### Supported Data Type Promotions
+### Supported Data Type Conversions
 
-OLake Go supports Iceberg v2's widening promotions, where the destination column type expands to accommodate a larger range or higher precision without data loss. These include:
+<Tabs queryString="handling-incompatible-data-types" groupId="handling-incompatible-data-types">
+  <TabItem value="iceberg" label="Iceberg" default>
 
-| From          | To                          | Notes                                                 |
-| ------------- | --------------------------- | ----------------------------------------------------- |
-| INT           | LONG (BIGINT)               | Widening integers is safe                             |
-| FLOAT         | DOUBLE                      | Promoting to higher precision works without data loss |
-| DATE          | TIMESTAMP, TIMESTAMP_NS     | Dates can be safely converted to timestamps           |
-| DECIMAL(P, S) | DECIMAL(P', S) where P' > P | Only widening precision is supported                  |
+      | From          | To                          | Notes                                                 |
+      | ------------- | --------------------------- | ----------------------------------------------------- |
+      | INT           | LONG (BIGINT) | Widening integers is safe              |
+      | FLOAT         | DOUBLE                      | Promoting to higher precision works without data loss |
+      | DATE          | TIMESTAMP     | Dates can be safely converted to timestamp           |
+      | INT, LONG, FLOAT, DOUBLE | STRING | If the destination data type is string, and incoming values are numeric, then the values are converted and stored as string. |
 
-:::info
-Writing an `INT` value into a `FLOAT` or `DOUBLE` column is supported in Iceberg, as it is considered a safe numeric conversion rather than a schema change.<br/> Similarly, writing a `BIGINT` value into a `DOUBLE` is also supported.
-:::
+      When a source value's data type has a smaller range or precision than the destination column's type, OLake Go handles it seamlessly. For example, if the destination column is defined as BIGINT but the incoming values are INT, OLake Go recognizes that every INT value falls within BIGINT's range and simply stores the values without error. 
+
+  </TabItem>
+  <TabItem value="parquet" label="Parquet">
+
+    ```text
+                            5 (String)
+                               /               
+                 3 (Float64)  /                  
+                             /  \                 
+                 2 (Int64)  /    \ 4 (Float32)   
+                           /                      
+                1 (Int32) /                      
+                         /                      
+               0 (Bool) /                      
+    ```
+
+    For Parquet destinations, OLake Go supports widening type conversions in this order:
+
+    **BOOLEAN** → **INT32** → **INT64** → **FLOAT64** → **STRING**
+
+    **FLOAT32** → **FLOAT64** → **STRING**
+
+    This means a type can be converted to any type on its right. For example:
+    - **BOOLEAN** can be converted to **INT32**, **INT64**, **FLOAT64**, or **STRING**
+    - **INT32** can be converted to **INT64**, **FLOAT64**, or **STRING**
+    - **INT64** can be converted to **FLOAT64** or **STRING**
+    - **FLOAT32** can be converted to **FLOAT64** or **STRING**
+    - **FLOAT64** can be converted to **STRING**
+  </TabItem>
+</Tabs>
 
 :::caution
 - Iceberg v2 supports widening type changes only. Narrowing changes (e.g., `BIGINT` to `INT`) along with any other data type changes will result in an errror as are not supported.
 - Parquet files are immutable. Existing files cannot be modified in place, so in-place data type changes and schema evolution at the file level are not supported.
 :::
 
-### Handling Incompatible Data Type Changes
-
-<Tabs queryString="handling-incompatible-data-types" groupId="handling-incompatible-data-types">
-  <TabItem value="iceberg" label="Iceberg" default>
-    For data type changes not supported by Iceberg v2: 
-      1. **(INT, LONG, FLOAT, DOUBLE) ➡ STRING** - OLake Go provides enhanced type conversion handling. At the destination if the data type is string, and incoming values are numeric, then the values are converted and stored as string.
-      2. Narrowing Type Conversions like: 
-         - **BIGINT to INT** 
-         - **DOUBLE to FLOAT**
-
-         When a source value's data type has a smaller range or precision than the destination column's type, OLake Go treats this as a narrowing conversion and handles it seamlessly. For example, if the destination column is defined as BIGINT but the incoming values are INT, OLake Go recognizes that every INT value falls within BIGINT's range and simply stores the values without error. This validation step ensures that compatible, smaller-range types are accepted even when Iceberg v2 would flag a mismatch.
-
-      :::tip
-      Any other incompatible data type changes will be captured by OLake Go using a Dead Letter Queue column (DLQ)  (feature coming soon).
-      :::
-  </TabItem>
-  <TabItem value="parquet" label="Parquet">
-    For Parquet destinations, OLake Go supports widening type conversions in this order:
-
-    **BOOLEAN** → **INT64** → **FLOAT64** → **STRING**
-
-    This means a type can be converted to any type on its right. For example:
-    - **BOOLEAN** can be converted to **INT64**, **FLOAT64**, or **STRING**
-    - **INT64** can be converted to **FLOAT64** or **STRING**
-    - **FLOAT64** can be converted to **STRING**
-  </TabItem>
-</Tabs>
-
-### Unsupported Data Type Conversions
-
-<Tabs queryString="unsupported-data-type-conversions" groupId="unsupported-data-type-conversions">
-  <TabItem value="iceberg" label="Iceberg" default>
-    The data type changes listed below are unsupported in Iceberg v2 and OLake Go. Attempting these will result in sync failure.
-
-    1. Attempting to write a `FLOAT` value into an `INT` column.
-    2. Attempting to write a `STRING` value into `INT/DOUBLE/LONG/FLOAT` column.
-  </TabItem>
-  <TabItem value="parquet" label="Parquet">
-    The data type changes listed below are unsupported in Parquet and OLake Go. Attempting these will result in sync failure.
-    - `STRING` cannot be converted to `FLOAT64`, `INT64`, or `BOOLEAN`
-  </TabItem>
-</Tabs>
-
 ## Example Scenarios
+
+<Tabs queryString="example-scenarios" groupId="example-scenarios">
+
+<TabItem value="iceberg" label="Iceberg" default>
 
 ### Scenario 1: Adding a Column in Source
 
@@ -136,7 +126,7 @@ When a table name changes in your source database:
 - A New table gets created
 - The old table name is retained in the destination schema but will not be populated with new data
 
-### Scenario 4: Widening Type Conversion 
+### Scenario 4: Widening Type Conversion
 
 The following conversions are handled:
 - **INT → BIGINT**
@@ -149,20 +139,7 @@ When a column data type is `INT` and it encounters `BIGINT` type or when a `FLOA
 - All values are properly converted
 - Pipeline continues without interruption
 
-### Scenario 5: Narrowing Type Conversion (BIGINT to INT Conversion)
-
-The following conversions are handled:
-- **BIGINT → INT**
-- **DOUBLE → FLOAT**
-
-When a column data type is `BIGINT` and it encounters `INT` type or when a `DOUBLE` column encounters a `FLOAT` type:
-
-- OLake Go detects the narrowing type change
-- Column type is validated in the destination making sure it fits in the target type's range
-- All values are properly approved
-- Pipeline continues without interruption
-
-### Scenario 6: Incompatible Type Change
+### Scenario 5: Incompatible Type Change
 
 The following conversions are handled:
 - **INT → STRING**
@@ -177,7 +154,7 @@ When a column data type is `STRING` and it encounters `NUMERIC` type:
 - Converted values are stored as strings in the destination
 - Pipeline continues without interruption
 
-### Scenario 7: Unsupported Type Change
+### Scenario 6: Unsupported Type Change
 
 When the column data type is `INT` and it encounters `FLOAT` or when a `NUMERIC` column encounters a `STRING` type:
 
@@ -185,3 +162,91 @@ When the column data type is `INT` and it encounters `FLOAT` or when a `NUMERIC`
 - The write is not allowed and the **sync fails**
 
 For more detailed information on Iceberg's schema evolution capabilities, refer to the [Apache Iceberg documentation](https://iceberg.apache.org/spec/#schema-evolution).
+
+</TabItem>
+
+<TabItem value="parquet" label="Parquet">
+
+### Scenario 1: Adding a Column in Source
+
+When a new column appears in your source data:
+
+- OLake Go automatically detects the new column
+- New columns are synced automatically only when **Sync new columns automatically** is enabled. If not user has to manually select those columns to be included in the sync
+- The column is added to your destination schema
+- New data includes values for this column
+- Historical data has null values for this column
+
+### Scenario 2: Adding a Table / Collection in Source
+
+When a new table appears in your source database:
+
+- OLake Go automatically detects the new table on the next scheduled run and lists it in the UI
+- The table is synced only when you explicitly enable it for the job
+- Once enabled, OLake Go creates the destination table and starts syncing using your configured sync mode
+
+### Scenario 3: Table Name Change
+
+When a table name changes in your source database:
+- OLake Go automatically detects the new table name
+- The table is added to your destination schema
+- A New table gets created
+- The old table name is retained in the destination schema but will not be populated with new data
+
+### Scenario 4: Widening Type Conversion
+
+The following conversions are handled:
+- **INT32 → INT64**
+- **INT64 → FLOAT64**
+- **FLOAT32 → FLOAT64**
+
+When a column data type is `INT32` and it encounters `INT64`, when an `INT64` column encounters `FLOAT32` or `FLOAT64`, or when a `FLOAT32` column encounters `FLOAT64`:
+
+- OLake Go detects the widening type change
+- Column type is updated for newly written Parquet files
+- All values are properly converted
+- Older Parquet files retain their original column type
+- Pipeline continues without interruption
+
+### Scenario 5: Boolean to Other Data Type Conversion
+
+The following conversions are handled:
+- **BOOLEAN → INT32**
+- **BOOLEAN → INT64**
+- **BOOLEAN → FLOAT64**
+- **BOOLEAN → STRING**
+
+When a column data type is `BOOLEAN` and it encounters `INT32`, `INT64`, `FLOAT64`, or `STRING`:
+
+- OLake Go detects the type change
+- Column type is updated for newly written Parquet files
+- Boolean values are properly converted
+- Older Parquet files retain their original column type
+- Pipeline continues without interruption
+
+### Scenario 6: Widening to String
+
+The following conversions are handled:
+- **INT32 → STRING**
+- **INT64 → STRING**
+- **FLOAT32 → STRING**
+- **FLOAT64 → STRING**
+
+When a column widens to `STRING` and incoming values are numeric:
+
+- OLake Go detects the type change
+- Numeric values are converted to their string representation
+- Converted values are stored as strings in newly written Parquet files
+- Pipeline continues without interruption
+
+### Scenario 7: Unsupported Type Change
+
+When a column is stored as `STRING` in Parquet and incoming values are `FLOAT64`, `INT64`, or `BOOLEAN`:
+
+- OLake Go detects the type mismatch
+- The write is not allowed and the **sync fails**
+
+</TabItem>
+
+</Tabs>
+


### PR DESCRIPTION
Updated schema evolution doc to remove redundant information and create separate sections for iceberg and parquet schema evolution