### PR TITLE
docs: release notes update for Go

### DIFF
--- a/docs/release/ingestion/v0.9.0.mdx
+++ b/docs/release/ingestion/v0.9.0.mdx
@@ -2,7 +2,7 @@
 title: "OLake Go (v0.9.0 - v0.9.5)"
 ---
 
-# OLake Go (v0.9.0 - v0.9.3)
+# OLake Go (v0.9.0 - v0.9.5)
 July 12, 2026 – Aug 28, 2026
 
 ## 🎯 What's New

--- a/docs/release/ingestion/v0.9.0.mdx
+++ b/docs/release/ingestion/v0.9.0.mdx
@@ -1,9 +1,9 @@
 ---
-title: "OLake Go (v0.9.0 - v0.9.3)"
+title: "OLake Go (v0.9.0 - v0.9.5)"
 ---
 
 # OLake Go (v0.9.0 - v0.9.3)
-July 12, 2026 – Aug 19, 2026
+July 12, 2026 – Aug 28, 2026
 
 ## 🎯 What's New
 
@@ -12,6 +12,8 @@ July 12, 2026 – Aug 19, 2026
 1. **S3 object storage abstraction -** <br/> Refactored the S3 source driver to use a storage-agnostic object store interface instead of directly depending on the AWS SDK. This simplifies testing and lays the groundwork for supporting additional object stores such as GCS and Azure Blob, while preserving existing S3 behavior.
 
 2. **XML file support for S3 -** <br/> Added XML file support to the S3 source, allowing OLake Go to ingest `.xml` and `.xml.gz` files.
+
+3. **Regex-based Kafka topic discovery -** <br/> Added regex support for Kafka topic discovery, allowing OLake Go to load only topics that match the configured pattern instead of loading all available topics.
 
 ### Platform Features
 
@@ -29,6 +31,10 @@ July 12, 2026 – Aug 19, 2026
 
 7. **Integration tests against shipped driver images -** <br/> Updated integration tests to run against the actual OLake driver Docker images, matching the environment and entrypoint used by deployed drivers. This ensures CI validates the shipped driver artifacts, including their runtime dependencies and entrypoint configuration, and catches image-specific regressions that were previously missed.
 
+8. **Enhanced telemetry for sync and error events -** <br/> Enhanced telemetry to provide better visibility into sync runs and failures without requiring user logs. Sync events now include stream-level metrics such as sync mode, selection, normalization, and partitioning, while a new failure event captures classified error information across sync and other CLI commands.
+
+9. **UI telemetry integration -** <br/> Added support for parsing telemetry configuration from the UI, allowing the CLI to use sync count, user ID, and event source information when sending telemetry events. This enables newer UI versions to delegate telemetry reporting to the CLI while maintaining backward compatibility with older UI versions.
+
 ### Catalogs
 
 1. **Google BigLake catalog support -** <br/> Upgraded Apache Iceberg to v1.10.2, adding support for the Google BigLake catalog. Now we can configure BigLake catalogs directly from OLake Go, including the required Google authentication and catalog settings.
@@ -38,6 +44,8 @@ July 12, 2026 – Aug 19, 2026
 ### Destinations
 
 1. **Rolling file writes for the S3 destination -** <br/> Added rolling file writes for the S3 destination, allowing large partitions to be written as multiple size-bounded files instead of a single output file. This reduces memory usage during syncs and produces more manageable output files for large datasets.
+
+2. **2PC recovery support for the Parquet destination -** <br/> Added two-phase commit (2PC) recovery support to the S3-backed Parquet destination, allowing committed full-refresh chunks and CDC/incremental checkpoints to be recovered after a sync failure. This prevents already committed data from being lost when OLake Go fails before saving the corresponding source state.
 
 ### Monitoring and Observability
 
@@ -76,3 +84,7 @@ July 12, 2026 – Aug 19, 2026
 15. **Fixed MySQL unsigned MEDIUMINT values in CDC -** <br/> Fixed an issue where unsigned MySQL `MEDIUMINT` values above 8,388,607 could be interpreted as negative numbers during CDC. Unsigned `MEDIUMINT` values are now correctly preserved when replicated to the destination.
 
 16. **Improved S3 integration test reliability -** <br/> Fixed flaky S3 integration tests that could fail when incremental update files were created within the same second. Added a wait in the test workflow to ensure files are processed reliably while preserving compatibility with existing S3 behavior.
+
+17. **Automatic incremental cursor selection -** <br/> OLake Go now automatically selects an incremental cursor field when one is not provided, using lexicographical ordering to determine the field.
+
+18. **Fixed connection check exit codes -** <br/> Fixed an issue where failed connection checks returned a non-zero exit code, causing the UI to lose the actual connection error and report a generic workflow failure instead. Connection checks now return their verdict through the connection status response while still reporting the failure through telemetry.


### PR DESCRIPTION
Updated the release notes OLake Go with v0.9.4 and 0.9.5