### PR TITLE
Update homepage SEO copy to cover ingestion and Fusion maintenance

### DIFF
--- a/src/data/landing/seo.ts
+++ b/src/data/landing/seo.ts
@@ -78,9 +78,9 @@ export const GO_SEO = {
 // five JSON-LD objects from the legacy homepage (src/legacy/home-v1/index.jsx)
 // rather than shipping the site root with no structured data.
 export const HOME_SEO = {
-  title: 'Fastest Open Source Data Replication Tool',
+  title: 'Fastest Open Source Iceberg Ingestion & Maintenance',
   description:
-    'Fastest open-source tool for replicating Databases to Data Lake in Open Table Formats like Apache Iceberg. Efficient, quick and scalable data ingestion for real-time analytics. Supporting Postgres, MongoDB, MySQL, Oracle and Kafka with 5-500x faster than alternatives.',
+    "Open-source platform to replicate databases into Apache Iceberg with OLake Go, and keep tables fast with OLake Fusion's automated compaction and maintenance.",
   canonicalUrl: `${SITE_URL}/`,
   ogImage: `${SITE_URL}/img/logo/olake-blue.webp`,
   jsonLdSchemas: [
@@ -103,9 +103,9 @@ export const HOME_SEO = {
         '@context': 'https://schema.org',
         '@type': 'WebSite',
         url: `${SITE_URL}/`,
-        name: 'Fastest Open Source Data Replication Tool',
+        name: 'Fastest Open Source Iceberg Ingestion & Maintenance',
         description:
-          'Fastest open-source tool for replicating Databases to Data Lake in Open Table Formats like Apache Iceberg. Efficient, quick and scalable data ingestion for real-time analytics. Supporting Postgres, MongoDB, MySQL, Oracle and Kafka with 5-500x faster than alternatives.',
+          'Open-source platform to replicate databases into Apache Iceberg with OLake Go, and keep tables fast with OLake Fusion\'s automated compaction and maintenance.',
         publisher: { '@type': 'Organization', name: 'OLake' },
         potentialAction: { '@type': 'SearchAction', target: 'https://olake.io/search?q={search_term_string}', 'query-input': 'required name=search_term_string' }
       }
@@ -116,10 +116,10 @@ export const HOME_SEO = {
         '@context': 'https://schema.org',
         '@type': 'WebPage',
         url: `${SITE_URL}/`,
-        name: 'OLake - Fastest Open Source Data Replication Tool',
+        name: 'OLake - Fastest Open Source Iceberg Ingestion & Maintenance',
         isPartOf: { '@type': 'WebSite', name: 'OLake' },
         description:
-          'Fastest open-source tool for replicating Databases to Data Lake in Open Table Formats like Apache Iceberg. Efficient, quick and scalable data ingestion for real-time analytics. Supporting Postgres, MongoDB, MySQL, Oracle and Kafka with 5-500x faster than alternatives.',
+          "Open-source platform to replicate databases into Apache Iceberg with OLake Go, and keep tables fast with OLake Fusion's automated compaction and maintenance.",
         publisher: { '@type': 'Organization', name: 'OLake', logo: { '@type': 'ImageObject', url: 'https://olake.io/img/site/hero-section.svg' } },
         primaryImageOfPage: { '@type': 'ImageObject', url: 'https://olake.io/img/site/hero-section.svg', width: 516, height: 605 }
       }

--- a/src/data/landing/seo.ts
+++ b/src/data/landing/seo.ts
@@ -78,7 +78,7 @@ export const GO_SEO = {
 // five JSON-LD objects from the legacy homepage (src/legacy/home-v1/index.jsx)
 // rather than shipping the site root with no structured data.
 export const HOME_SEO = {
-  title: 'Fastest Open Source Iceberg Ingestion & Maintenance',
+  title: 'Fastest Open Source Iceberg Ingestion & Maintenance Platform',
   description:
     "Open-source platform to replicate databases into Apache Iceberg with OLake Go, and keep tables fast with OLake Fusion's automated compaction and maintenance.",
   canonicalUrl: `${SITE_URL}/`,
@@ -103,7 +103,7 @@ export const HOME_SEO = {
         '@context': 'https://schema.org',
         '@type': 'WebSite',
         url: `${SITE_URL}/`,
-        name: 'Fastest Open Source Iceberg Ingestion & Maintenance',
+        name: 'Fastest Open Source Iceberg Ingestion & Maintenance Platform',
         description:
           'Open-source platform to replicate databases into Apache Iceberg with OLake Go, and keep tables fast with OLake Fusion\'s automated compaction and maintenance.',
         publisher: { '@type': 'Organization', name: 'OLake' },
@@ -116,7 +116,7 @@ export const HOME_SEO = {
         '@context': 'https://schema.org',
         '@type': 'WebPage',
         url: `${SITE_URL}/`,
-        name: 'OLake - Fastest Open Source Iceberg Ingestion & Maintenance',
+        name: 'OLake - Fastest Open Source Iceberg Ingestion & Maintenance Platform',
         isPartOf: { '@type': 'WebSite', name: 'OLake' },
         description:
           "Open-source platform to replicate databases into Apache Iceberg with OLake Go, and keep tables fast with OLake Fusion's automated compaction and maintenance.",


### PR DESCRIPTION
## Summary
- Homepage `<title>`, meta description, and both `website`/`webpage` JSON-LD blocks only described OLake Go (database → Iceberg ingestion), even though the homepage itself also markets OLake Fusion (scheduled Iceberg compaction/table maintenance).
- Updated all 5 occurrences in `HOME_SEO` (`src/data/landing/seo.ts`) so the title and description now cover both ingestion and maintenance:
  - Title: "Fastest Open Source Iceberg Ingestion & Maintenance"
  - Description: "Open-source platform to replicate databases into Apache Iceberg with OLake Go, and keep tables fast with OLake Fusion's automated compaction and maintenance."
- Scoped to the homepage only — product pages (OLake Go / OLake Fusion) keep their own SEO copy and are unaffected.
